### PR TITLE
Added a few more members to CarState

### DIFF
--- a/carstate.cpp
+++ b/carstate.cpp
@@ -121,7 +121,7 @@ void CarState::draw(QPainter &painter, const QTransform &drawTrans, const QTrans
 
 double CarState::getAxisDistance() const
 {
-    return mAxisDistance;
+	return fabs(mAxisDistance) < 0.001 ? 0.8*getLength() : mAxisDistance;
 }
 
 void CarState::setAxisDistance(double axisDistance)
@@ -139,6 +139,14 @@ void CarState::setSteering(double value)
     value = (value > tanf(getMaxSteeringAngle())) ? tanf(getMaxSteeringAngle()) : value;
     value = (value < -tanf(getMaxSteeringAngle())) ? -tanf(getMaxSteeringAngle()) : value;
     mSteering = value;
+}
+
+void CarState::setMaxSteeringAngle(double steeringAngle_rad) {
+	mMaxSteeringAngle = fabs(steeringAngle_rad);
+}
+
+void CarState::setMinTurnRadiusRear(double minTurnRadius_m) {
+	mMinTurnRadiusRear = fabs(minTurnRadius_m);
 }
 
 double CarState::getBrakingDistance() const {

--- a/carstate.h
+++ b/carstate.h
@@ -18,8 +18,10 @@ public:
 
     // Static state
     double getAxisDistance() const;
-    void setAxisDistance(double axisDistance);
-    inline double getMaxSteeringAngle() const { return M_PI/4.0; }; // = 45°, fixed for now
+	void setAxisDistance(double axisDistance);
+	inline double getMaxSteeringAngle() const { return mMaxSteeringAngle < M_PI/180.0 ? M_PI/4.0 : mMaxSteeringAngle; } // 45° assumed if unset
+	void setMaxSteeringAngle(double steeringAngle_rad);
+	void setMinTurnRadiusRear(double minTurnRadius_m);
 
     // Dynamic state
     double getSteering() const;
@@ -31,11 +33,13 @@ public:
     double getThreeSecondsDistance() const; // Distance the vehicle can move within 3 seconds at current speed, Swedish "Tresekundersregeln"
     const QPointF getStoppingPointForTurnRadiusAndBrakingDistance(const double turnRadius, const double brakeDistance) const;
     const QPointF getStoppingPointForTurnRadius(const double turnRadius) const;
-    inline double getMinTurnRadiusRear() const { return qMax(mAxisDistance / tanf(getMaxSteeringAngle()), pow(getSpeed(), 2)/(0.21*9.81)); }
+	inline double getMinTurnRadiusRear() const { return qMin(qMax(mAxisDistance / tanf(getMaxSteeringAngle()), pow(getSpeed(), 2)/(0.21*9.81)), mMinTurnRadiusRear); }
 
 private:
     double mAxisDistance; // [m]
     double mSteering = 0.0; // [-1.0:1.0]
+	double mMaxSteeringAngle = 0.0; // [rad]
+	double mMinTurnRadiusRear = std::numeric_limits<double>::infinity(); // [m]
 };
 
 #endif // CARSTATE_H


### PR DESCRIPTION
This is an attempt to follow the "be generous in what you accept, but picky in what you output" rule. In order to allow for setting of the turn radius both via measurement of the two variables "max steering angle" and "axis distance" as well as a simple experiment of turning the vehicle, I added support for both in CarState.

It does however not sit right with me to have members that can be inferred based on each other, so any suggestion which makes it possible to keep using axis distance & max steering angle while still being able to accept a rearTurnRadius message is most welcome.

@marvind it is up to you whether or not this is a good idea.