### PR TITLE
Send NMEA GGA to NTRIP Server

### DIFF
--- a/sensors/gnss/rtcmclient.cpp
+++ b/sensors/gnss/rtcmclient.cpp
@@ -124,7 +124,7 @@ void RtcmClient::forwardNmeaGgaToServer(const QByteArray &nmeaGgaStr)
 {
     // Send NMEA GGA to NTRIP/RTCM server until we got reference station information.
     // Some NTRIP servers will not start sending RTCM unless they got NMEA GGA.
-    if (isConnected() && mSkippedFirstReply && !mFoundReferenceStationInfo)
+    if (isConnected() && mSkippedFirstReply)
         mTcpSocket.write(nmeaGgaStr);
 }
 

--- a/sensors/gnss/rtcmclient.cpp
+++ b/sensors/gnss/rtcmclient.cpp
@@ -12,9 +12,8 @@ RtcmClient::RtcmClient(QObject *parent) : QObject(parent)
 //        qDebug() << data;
 
         // Make sure to skip "ICY 200 OK" when connection to NTRIP
-        static bool skipFirstReply = true;
-        if (skipFirstReply) {
-            skipFirstReply = false;
+        if (!mSkippedFirstReply) {
+            mSkippedFirstReply = true;
             return;
         }
 
@@ -125,7 +124,7 @@ void RtcmClient::forwardNmeaGgaToServer(const QByteArray &nmeaGgaStr)
 {
     // Send NMEA GGA to NTRIP/RTCM server until we got reference station information.
     // Some NTRIP servers will not start sending RTCM unless they got NMEA GGA.
-    if (isConnected() && !mFoundReferenceStationInfo)
+    if (isConnected() && mSkippedFirstReply && !mFoundReferenceStationInfo)
         mTcpSocket.write(nmeaGgaStr);
 }
 

--- a/sensors/gnss/rtcmclient.h
+++ b/sensors/gnss/rtcmclient.h
@@ -54,6 +54,7 @@ private:
     qint16 mCurrentPort;
     NtripConnectionInfo mCurrentNtripConnectionInfo;
     bool mFoundReferenceStationInfo = false;
+    bool mSkippedFirstReply = false;
 
     // For parsing RTCMv3 (from RTKLIB)
     const char RTCM3_PREAMBLE = 0xD3;

--- a/sensors/gnss/rtcmclient.h
+++ b/sensors/gnss/rtcmclient.h
@@ -39,10 +39,10 @@ public:
     bool isConnected();
     void disconnect();
     static llh_t decodeLllhFromReferenceStationInfo(const QByteArray data);
-
     QString getCurrentHost() const;
-
     qint16 getCurrentPort() const;
+
+    void forwardNmeaGgaToServer(const QByteArray& nmeaGgaStr);
 
 signals:
     void rtcmData(const QByteArray &data);
@@ -53,6 +53,7 @@ private:
     QString mCurrentHost;
     qint16 mCurrentPort;
     NtripConnectionInfo mCurrentNtripConnectionInfo;
+    bool mFoundReferenceStationInfo = false;
 
     // For parsing RTCMv3 (from RTKLIB)
     const char RTCM3_PREAMBLE = 0xD3;

--- a/sensors/gnss/ublox.cpp
+++ b/sensors/gnss/ublox.cpp
@@ -1134,7 +1134,35 @@ void Ublox::serialDataAvailable()
                 }
             }
 
-            // Note: see RConstrolStation for NMEA support
+            // NMEA
+            if (!ch_used) {
+                mDecoderState.line[mDecoderState.line_pos++] = ch;
+                if (mDecoderState.line_pos == sizeof (mDecoderState.line)) {
+                    mDecoderState.line_pos = 0;
+                }
+
+                if (mDecoderState.line_pos > 0 && mDecoderState.line[mDecoderState.line_pos - 1] == '\n') {
+                    mDecoderState.line[mDecoderState.line_pos] = '\0';
+                    mDecoderState.line_pos = 0;
+
+                    QByteArray line((char*)mDecoderState.line);
+                    // Check whether this is NMEA GGA with correct checksum
+                    // Example: $GPGGA,120020.115,5743.153,N,01256.431,E,1,12,1.0,0.0,M,0.0,M,,*6E
+                    QByteArray gpggaStr = "$GPGGA";
+                    if (line.size() > gpggaStr.size())
+                        if (line.mid(0, gpggaStr.size()).compare(gpggaStr) == 0) {
+                            QList split = line.split('*');
+                            if (split.size() == 2) {
+                                // Test checksum
+                                int checksum = 0;
+                                for (int i = 1; i < split.at(0).size(); i++)
+                                    checksum ^= split.at(0).at(i);
+                                if (checksum == split.at(1).trimmed().toInt(nullptr, 16))
+                                    emit rxNmeaGga(line);
+                            }
+                        }
+                }
+            }
         }
     }
 }

--- a/sensors/gnss/ublox.cpp
+++ b/sensors/gnss/ublox.cpp
@@ -1147,10 +1147,9 @@ void Ublox::serialDataAvailable()
 
                     QByteArray line((char*)mDecoderState.line);
                     // Check whether this is NMEA GGA with correct checksum
-                    // Example: $GPGGA,120020.115,5743.153,N,01256.431,E,1,12,1.0,0.0,M,0.0,M,,*6E
-                    QByteArray gpggaStr = "$GPGGA";
-                    if (line.size() > gpggaStr.size())
-                        if (line.mid(0, gpggaStr.size()).compare(gpggaStr) == 0) {
+                    // Example: $GNGGA,120020.115,5743.153,N,01256.431,E,1,12,1.0,0.0,M,0.0,M,,*6E
+                    if (line.at(0) == '$' && line.size() > 6)
+                        if (line.mid(3, 3).compare("GGA") == 0) {
                             QList split = line.split('*');
                             if (split.size() == 2) {
                                 // Test checksum

--- a/sensors/gnss/ublox.h
+++ b/sensors/gnss/ublox.h
@@ -648,6 +648,7 @@ signals:
     void ubxRx(const QByteArray &data);
     void rtcmRx(const QByteArray &data, const int &type);
     void rxUpdSos(const ubx_upd_sos &sos);
+    void rxNmeaGga(const QByteArray &nmeaGgaStr);
 
 public slots:
 

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -20,6 +20,9 @@ UbloxRover::UbloxRover(QSharedPointer<VehicleState> vehicleState)
     // Save-on-shutdown feature
     connect(&mUblox, &Ublox::rxUpdSos, this, &UbloxRover::updSosResponse);
 
+    // Fordward received NMEA GGA messages
+    connect(&mUblox, &Ublox::rxNmeaGga, this, &UbloxRover::gotNmeaGga);
+
     // Automatic IMU orientation alignment feature
     connect(&mUblox, &Ublox::rxEsfAlg, this, [this](const ubx_esf_alg &alg){
         if (alg.autoMntAlgOn)
@@ -206,8 +209,10 @@ bool UbloxRover::configureUblox()
         result &= mUblox.ubxCfgMsg(UBX_CLASS_RTCM3, UBX_RTCM3_4072_1, 0);
         result &= mUblox.ubxCfgMsg(UBX_CLASS_NAV, UBX_NAV_SVIN, 0);
 
-        // Disable NMEA output
-        result &= mUblox.ubxCfgMsg(UBX_CLASS_NMEA, UBX_NMEA_GGA, 0);
+        // Enable NMEA GGA output (required by some NTRIP/RTCM servers)
+        result &= mUblox.ubxCfgMsg(UBX_CLASS_NMEA, UBX_NMEA_GGA, 1);
+
+        // Disable NMEA output (all but GGA)
         result &= mUblox.ubxCfgMsg(UBX_CLASS_NMEA, UBX_NMEA_GSV, 0);
         result &= mUblox.ubxCfgMsg(UBX_CLASS_NMEA, UBX_NMEA_GLL, 0);
         result &= mUblox.ubxCfgMsg(UBX_CLASS_NMEA, UBX_NMEA_GSA, 0);

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -32,6 +32,7 @@ public:
 signals:
     void updatedGNSSPositionAndYaw(QSharedPointer<VehicleState> vehicleState, double distanceMoved, bool fused);
     void txNavPvt(const ubx_nav_pvt &pvt);
+    void gotNmeaGga(const QByteArray& nmeaGgaStr);
 
 private:
     bool configureUblox();


### PR DESCRIPTION
Some NTRIP servers (like SWEPOS) determine which rtcm to send using the rover's position. In that case, NMEA GGA messages from the rover's GNSS receiver need to be forwarded to the NTRIP server (the NTRIP server will not send any RTCM otherwise).

The following line needs to be added in the vehicle's main (after declaring RtcmClient):
`QObject::connect(mUbloxRover.get(), &UbloxRover::gotNmeaGga, &rtcmClient, &RtcmClient::forwardNmeaGgaToServer);`