### PR TITLE
PurepursuitWaypointFollower: emergency brake for detected objects

### DIFF
--- a/autopilot/emergencybrake.cpp
+++ b/autopilot/emergencybrake.cpp
@@ -3,33 +3,37 @@
 EmergencyBrake::EmergencyBrake(QObject *parent)
     : QObject{parent}
 {
-    connect(&mUpdateStateTimer, &QTimer::timeout, this, &EmergencyBrake::decissionLogic);
+
 }
 
 void EmergencyBrake::deactivateEmergencyBrake()
 {
-    mUpdateStateTimer.stop();
+    mCurrentState.emergencyBrakeIsActive = false;
 };
 
 void EmergencyBrake::activateEmergencyBrake()
 {
-    mUpdateStateTimer.start(mUpdateStatePeriod_ms);
+    mCurrentState.emergencyBrakeIsActive = true;
 };
 
-void EmergencyBrake::camera(const PosPoint &point)
+void EmergencyBrake::brakeForDetectedCameraObject(const PosPoint &detectedObject)
 {
     //When no object is detected, objectDistance is zero
-    double objectDistance = sqrt(point.getX()*point.getX() + point.getY()*point.getY() + point.getHeight()*point.getHeight());
+    double objectDistance = sqrt(detectedObject.getX()*detectedObject.getX() + detectedObject.getY()*detectedObject.getY() + detectedObject.getHeight()*detectedObject.getHeight());
 
-    if (objectDistance > 0 && objectDistance < objectBrakeDistance)
-        mCurrentState.cameraBrake = true;
+    if (objectDistance > 0 && objectDistance < mCurrentState.brakeForObjectAtDistance)
+        mCurrentState.brakeForDetectedCameraObject = true;
     else
-        mCurrentState.cameraBrake = false;
+        mCurrentState.brakeForDetectedCameraObject = false;
+
+    fuseSensorsAndTakeBrakeDecision();
 };
 
-void EmergencyBrake::decissionLogic()
+void EmergencyBrake::fuseSensorsAndTakeBrakeDecision()
 {
-    // ToDo: create decission logic depending on multiple sensor inputs
-    if (mCurrentState.cameraBrake)
-        emit emergencyBrake();
+    if (mCurrentState.emergencyBrakeIsActive) {
+        // ToDo: create decission logic depending on multiple sensor inputs
+        if (mCurrentState.brakeForDetectedCameraObject)
+            emit emergencyBrake();
+    }
 }

--- a/autopilot/emergencybrake.cpp
+++ b/autopilot/emergencybrake.cpp
@@ -1,0 +1,35 @@
+#include "emergencybrake.h"
+
+EmergencyBrake::EmergencyBrake(QObject *parent)
+    : QObject{parent}
+{
+    connect(&mUpdateStateTimer, &QTimer::timeout, this, &EmergencyBrake::decissionLogic);
+}
+
+void EmergencyBrake::deactivateEmergencyBrake()
+{
+    mUpdateStateTimer.stop();
+};
+
+void EmergencyBrake::activateEmergencyBrake()
+{
+    mUpdateStateTimer.start(mUpdateStatePeriod_ms);
+};
+
+void EmergencyBrake::camera(const PosPoint &point)
+{
+    //When no object is detected, objectDistance is zero
+    double objectDistance = sqrt(point.getX()*point.getX() + point.getY()*point.getY() + point.getHeight()*point.getHeight());
+
+    if (objectDistance > 0 && objectDistance < objectBrakeDistance)
+        mCurrentState.cameraBrake = true;
+    else
+        mCurrentState.cameraBrake = false;
+};
+
+void EmergencyBrake::decissionLogic()
+{
+    // ToDo: create decission logic depending on multiple sensor inputs
+    if (mCurrentState.cameraBrake)
+        emit emergencyBrake();
+}

--- a/autopilot/emergencybrake.h
+++ b/autopilot/emergencybrake.h
@@ -6,9 +6,11 @@
 #include "core/pospoint.h"
 
 struct EmergencyBrakeState {
-    bool cameraBrake = false;
-    bool lidarBrake = false;
-    bool radarBrake = false;
+    bool brakeForDetectedCameraObject = false;
+    bool brakeForDetectedLidarObject = false;
+    bool brakeForDetectedRadarObject = false;
+    double brakeForObjectAtDistance = 10; // [m] brake when detected object comes closer than
+    bool emergencyBrakeIsActive = false;
 };
 
 class EmergencyBrake : public QObject
@@ -23,14 +25,11 @@ signals:
 public slots:
     void deactivateEmergencyBrake();
     void activateEmergencyBrake();
-    void camera(const PosPoint &detectedObject);
+    void brakeForDetectedCameraObject(const PosPoint &detectedObject);
 
 private:
-    double objectBrakeDistance = 10; // [m] brake when detected object comes closer than
     EmergencyBrakeState mCurrentState;
-    unsigned mUpdateStatePeriod_ms = 50;
-    QTimer mUpdateStateTimer;
-    void decissionLogic();
+    void fuseSensorsAndTakeBrakeDecision();
 };
 
 #endif // EMERGENCYBRAKE_H

--- a/autopilot/emergencybrake.h
+++ b/autopilot/emergencybrake.h
@@ -1,0 +1,36 @@
+#ifndef EMERGENCYBRAKE_H
+#define EMERGENCYBRAKE_H
+
+#include <QObject>
+#include <QTimer>
+#include "core/pospoint.h"
+
+struct EmergencyBrakeState {
+    bool cameraBrake = false;
+    bool lidarBrake = false;
+    bool radarBrake = false;
+};
+
+class EmergencyBrake : public QObject
+{
+    Q_OBJECT
+public:
+    explicit EmergencyBrake(QObject *parent = nullptr);
+
+signals:
+    void emergencyBrake();
+
+public slots:
+    void deactivateEmergencyBrake();
+    void activateEmergencyBrake();
+    void camera(const PosPoint &detectedObject);
+
+private:
+    double objectBrakeDistance = 10; // [m] brake when detected object comes closer than
+    EmergencyBrakeState mCurrentState;
+    unsigned mUpdateStatePeriod_ms = 50;
+    QTimer mUpdateStateTimer;
+    void decissionLogic();
+};
+
+#endif // EMERGENCYBRAKE_H

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -265,6 +265,7 @@ void PurepursuitWaypointFollower::updateState()
         break;
 
     case WayPointFollowerSTMstates::FOLLOW_ROUTE_GOTO_BEGIN: {
+        emergencyBrake(mCurrentState.detectedObjectInVehicleFrame);
         calculateDistanceOfRouteLeft();
         currentVehiclePositionXY = getCurrentVehiclePosition().getPoint();
 
@@ -280,6 +281,7 @@ void PurepursuitWaypointFollower::updateState()
     } break;
 
     case WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING: {
+        emergencyBrake(mCurrentState.detectedObjectInVehicleFrame);
         calculateDistanceOfRouteLeft();
         currentVehiclePositionXY = getCurrentVehiclePosition().getPoint();
         QPointF currentWaypointPoint = mWaypointList.at(mCurrentState.currentWaypointIndex).getPoint();
@@ -495,4 +497,18 @@ double PurepursuitWaypointFollower::purePursuitRadius()
         vehicleState->setAutopilotRadius(mCurrentState.purePursuitRadius);
 
     return vehicleState->getAutopilotRadius();
+}
+
+void PurepursuitWaypointFollower::emergencyBrake(const PosPoint &point)
+{
+    double objectDistance = sqrt(point.getX()*point.getX() + point.getY()*point.getY() + point.getHeight()*point.getHeight());
+
+    //When no object is detected, objectDistance is zero
+    if (objectDistance > 0 && objectDistance < mCurrentState.emergencyBrakeDistance)
+        stop();
+}
+
+void PurepursuitWaypointFollower::updateDetectedObjectInVehicleFrame(const PosPoint &point)
+{
+    mCurrentState.detectedObjectInVehicleFrame = point;
 }

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -91,6 +91,7 @@ void PurepursuitWaypointFollower::stop()
     (isOnVehicle() ? mMovementController->getVehicleState() : mVehicleConnection->getVehicleState())->setAutopilotRadius(0);
     holdPosition();
     emit txDistOfRouteLeft(0);
+    emit deactivateEmergencyBrake();
 }
 
 void PurepursuitWaypointFollower::startFollowPoint()

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -26,9 +26,11 @@ struct WayPointFollowerState {
     int currentWaypointIndex;
     bool adaptivePurePursuitRadius = false;
     double purePursuitRadius = 1.0;
+    PosPoint detectedObjectInVehicleFrame;
     // Follow Route
     int numWaypointsLookahead = 8;
     bool repeatRoute = false;
+    double emergencyBrakeDistance = 10; // [m] brake when object comes closer than
     // -- for flying vehicles
     double overrideAltitude = 0.0;
     // Follow Point
@@ -84,6 +86,7 @@ signals:
 
 public slots:
     void updateFollowPointInVehicleFrame(const PosPoint &point);
+    void updateDetectedObjectInVehicleFrame(const PosPoint &point);
 
 private:
     const unsigned mFollowPointTimeout_ms = 1000;
@@ -104,6 +107,7 @@ private:
     void holdPosition();
     void calculateDistanceOfRouteLeft();
     double purePursuitRadius();
+    void emergencyBrake(const PosPoint &point);
 };
 
 #endif // PUREPURSUITWAYPOINTFOLLOWER_H

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -26,11 +26,9 @@ struct WayPointFollowerState {
     int currentWaypointIndex;
     bool adaptivePurePursuitRadius = false;
     double purePursuitRadius = 1.0;
-    PosPoint detectedObjectInVehicleFrame;
     // Follow Route
     int numWaypointsLookahead = 8;
     bool repeatRoute = false;
-    double emergencyBrakeDistance = 10; // [m] brake when object comes closer than
     // -- for flying vehicles
     double overrideAltitude = 0.0;
     // Follow Point
@@ -86,7 +84,6 @@ signals:
 
 public slots:
     void updateFollowPointInVehicleFrame(const PosPoint &point);
-    void updateDetectedObjectInVehicleFrame(const PosPoint &point);
 
 private:
     const unsigned mFollowPointTimeout_ms = 1000;
@@ -107,7 +104,6 @@ private:
     void holdPosition();
     void calculateDistanceOfRouteLeft();
     double purePursuitRadius();
-    void emergencyBrake(const PosPoint &point);
 };
 
 #endif // PUREPURSUITWAYPOINTFOLLOWER_H

--- a/autopilot/waypointfollower.h
+++ b/autopilot/waypointfollower.h
@@ -34,7 +34,8 @@ public:
     virtual void startFollowPoint() {throw std::logic_error("WaypointFollower::startFollowPoint() not implemented.");};
 
 signals:
-
+    void deactivateEmergencyBrake();
+    void activateEmergencyBrake();
 };
 
 #endif // WAYPOINTFOLLOWER_H


### PR DESCRIPTION
The following line needs to be added in the vehicle's main:
   // Emergency brake
    EmergencyBrake mEmergencyBrake;
    QObject::connect(&mDepthAiCamera, &DepthAiCamera::closestObject, &mEmergencyBrake, &EmergencyBrake::brakeForDetectedCameraObject);
    QObject::connect(mWaypointFollower.get(), &WaypointFollower::deactivateEmergencyBrake, &mEmergencyBrake, &EmergencyBrake::deactivateEmergencyBrake);
    QObject::connect(mWaypointFollower.get(), &WaypointFollower::activateEmergencyBrake, &mEmergencyBrake, &EmergencyBrake::activateEmergencyBrake);
    QObject::connect(&mEmergencyBrake, &EmergencyBrake::emergencyBrake, mWaypointFollower.get(), &WaypointFollower::stop);
