### PR TITLE
Close CANopen thread

### DIFF
--- a/communication/CANopen/canopencontrollerinterface.cpp
+++ b/communication/CANopen/canopencontrollerinterface.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
  *               2021 Rickard Häll      rickard.hall@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
@@ -68,6 +68,10 @@ void CANopenControllerInterface::rxDistOfRouteLeft(double dist) {
     emit txDistOfRouteLeft(dist);
 }
 
+void CANopenControllerInterface::finishEventLoop() {
+    mContinueEventLoop = false;
+}
+
 // --- PROCESS ---
 // Start processing data.
 void CANopenControllerInterface::startDevice() {
@@ -127,7 +131,7 @@ void CANopenControllerInterface::startDevice() {
         // command.
         mSlave.Reset();
         // Run the event loop once, then check for Qt events
-        while (true) {
+        while (mContinueEventLoop) {
             loop.run_one();
             thread()->eventDispatcher()->processEvents(QEventLoop::ProcessEventsFlag::AllEvents);
         }
@@ -135,4 +139,5 @@ void CANopenControllerInterface::startDevice() {
         qDebug() << "WARNING: CANopenControllerInterface could not open CAN device, trying to activate simulation.";
         emit activateSimulation();
     }
+    emit finished();
 }

--- a/communication/CANopen/canopencontrollerinterface.h
+++ b/communication/CANopen/canopencontrollerinterface.h
@@ -28,6 +28,7 @@ public slots:
     void commandAttributesReceived(const quint32& attributes);
     void GNSSDataToCANReceived(const QVariant& gnssData);
     void rxDistOfRouteLeft(double dist);
+    void finishEventLoop();
 
 signals:
     void finished();
@@ -44,6 +45,9 @@ signals:
     void activateSimulation();
     void sendGNSSDataToCAN(const QVariant&);
     void txDistOfRouteLeft(double dist);
+
+private:
+    bool mContinueEventLoop = true;
 };
 
 #endif // CANOPENCONTROLLERINTERFACE_H

--- a/communication/CANopen/canopenmovementcontroller.h
+++ b/communication/CANopen/canopenmovementcontroller.h
@@ -29,6 +29,7 @@ class CANopenMovementController : public MovementController
     Q_OBJECT
 public:
     CANopenMovementController(QSharedPointer<VehicleState> vehicleState);
+    ~CANopenMovementController();
 
     // MovementController interface
     virtual void setDesiredSpeed(double desiredSpeed) override;
@@ -67,6 +68,5 @@ private:
 
     QSharedPointer<QThread> mCanopenThread;
     QSharedPointer<CANopenControllerInterface> mCANopenControllerInterface;
-
 };
 #endif // CANOPENMOVEMENTCONTROLLER_H


### PR DESCRIPTION
Fix for:
QThread: Destroyed while thread is still running

Now there is "warning: io_can_net_fini() invoked with pending operations"
This commes from inside CANopenControllerInterface::startDevice() and is generated by Lely:
https://lely_industries.gitlab.io/lely-core/doxygen/can__net_8c_source.html#:~:text=%22io_can_net_fini()%20invoked%20with%20pending%20operations%22)%3B

Dont forget to comment out in main when testing:
    QObject::connect(&mMavsdkVehicleServer, &MavsdkVehicleServer::shutdownOrRebootOnboardComputer, [&](bool isShutdown){
        qApp->quit();
        if (isShutdown) {
           qDebug() << "\nSystem shutdown...";
//           QProcess::startDetached("sudo", QStringList() << "shutdown" << "-P" << "now");
        }else {
           qDebug() << "\nSystem reboot...";
//           QProcess::startDetached("sudo", QStringList() << "shutdown" << "-r" << "now");
        }
    });