### PR TITLE
UbloxRover: allow setting GNSS antenna offset

### DIFF
--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -28,6 +28,7 @@ public:
     void writeOdoToUblox(ubx_esf_datatype_enum dataType, uint32_t dataField);
     void saveOnShutdown();
     void setIMUOrientationOffset(double roll_deg, double pitch_deg, double yaw_deg);
+    void setGNSSPositionOffset(double xOffset, double yOffset);
 
 signals:
     void updatedGNSSPositionAndYaw(QSharedPointer<VehicleState> vehicleState, double distanceMoved, bool fused);
@@ -47,6 +48,7 @@ private:
     Ublox mUblox;
     QSharedPointer<VehicleState> mVehicleState;
     struct {double rollOffset_deg, pitchOffset_deg, yawOffset_deg;} mIMUOrientationOffset;
+    xyz_t mGNSSPositionOffset = {0.0, 0.0, 0.0};
 };
 
 #endif // UBLOXROVER_H


### PR DESCRIPTION
Let's say your vehicle's reference point is your back axle, but your GNSS antenna has an offset to it. Then, this feature allows you to adjust the reported GNSS position from the antenna's position to the back axle.