### PR TITLE
Created wrapper class for mavsdk::ParamServer, MavsdkVehicleServer: c…

### DIFF
--- a/communication/mavlinkparameterserver.cpp
+++ b/communication/mavlinkparameterserver.cpp
@@ -1,0 +1,50 @@
+#include "mavlinkparameterserver.h"
+#include <QXmlStreamWriter>
+#include <QFile>
+#include <QDebug>
+
+MavlinkParameterServer::MavlinkParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent)
+{
+    mMavsdkParamServer = new mavsdk::ParamServer(serverComponent);
+
+    // These are needed for MAVSDK at the moment
+    mMavsdkParamServer->provide_param_int("CAL_ACC0_ID", 1);
+    mMavsdkParamServer->provide_param_int("CAL_GYRO0_ID", 1);
+    mMavsdkParamServer->provide_param_int("CAL_MAG0_ID", 1);
+    mMavsdkParamServer->provide_param_int("SYS_HITL", 0);
+    mMavsdkParamServer->provide_param_int("MIS_TAKEOFF_ALT", 0);
+}
+
+void MavlinkParameterServer::provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction)
+{
+    mParameterToClassMapping.insert_or_assign(parameterName, std::make_pair(setClassParameterFunction, getClassParameterFunction));
+    mMavsdkParamServer->provide_param_float(parameterName, getClassParameterFunction());
+};
+
+void MavlinkParameterServer::saveParametersToXmlFile()
+{
+    mavsdk::ParamServer::AllParams parameters = mMavsdkParamServer->retrieve_all_params();
+    QFile parameterFile("vehicle_parameters.xml");
+
+    if (!parameterFile.open(QIODevice::WriteOnly))
+        qDebug() << "Could not save parameters";
+
+    QXmlStreamWriter stream(&parameterFile);
+    stream.setCodec("UTF-8");
+    stream.setAutoFormatting(true);
+    stream.writeStartDocument();
+
+    for (const auto& vehicleParameter : parameters.int_params) {
+        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
+    }
+    for (const auto& vehicleParameter : parameters.float_params) {
+        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
+    }
+    for (const auto& vehicleParameter : parameters.custom_params) {
+        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::fromStdString(vehicleParameter.value));
+    }
+
+    stream.writeEndElement();
+    stream.writeEndDocument();
+    parameterFile.close();
+};

--- a/communication/mavlinkparameterserver.h
+++ b/communication/mavlinkparameterserver.h
@@ -1,0 +1,21 @@
+#ifndef MAVLINKPARAMETERSERVER_H
+#define MAVLINKPARAMETERSERVER_H
+
+#include <QObject>
+#include <mavsdk/server_component.h>
+#include <mavsdk/plugins/param_server/param_server.h>
+#include "communication/parameterserver.h"
+
+class MavlinkParameterServer : public ParameterServer
+{
+    Q_OBJECT
+public:
+    explicit MavlinkParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
+    virtual void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction) override;
+    virtual void saveParametersToXmlFile() override;
+
+private:
+    mavsdk::ParamServer *mMavsdkParamServer;
+};
+
+#endif // PARAMETERSERVER_H

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -24,7 +24,7 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
     mTelemetryServer.reset(new mavsdk::TelemetryServer(serverComponent));
     mActionServer.reset(new mavsdk::ActionServer(serverComponent));
     mMissionRawServer.reset(new mavsdk::MissionRawServer(serverComponent));
-    mParameterServer.reset(new ParameterServer(serverComponent));
+    mParameterServer.reset(new MavlinkParameterServer(serverComponent));
 
     // Allow the vehicle to change to auto mode (manual is always allowed) and arm, disable takeoff (only rover support for now)
     mActionServer->set_allowable_flight_modes({true, false, false});

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -10,8 +10,6 @@
 #include <QMetaMethod>
 #include <algorithm>
 #include <chrono>
-#include <QXmlStreamWriter>
-#include <QFile>
 
 MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState)
 {
@@ -25,15 +23,8 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
     // Create server plugins
     mTelemetryServer.reset(new mavsdk::TelemetryServer(serverComponent));
     mActionServer.reset(new mavsdk::ActionServer(serverComponent));
-    mParamServer.reset(new mavsdk::ParamServer(serverComponent));
     mMissionRawServer.reset(new mavsdk::MissionRawServer(serverComponent));
-
-    // These are needed for MAVSDK at the moment
-    mParamServer->provide_param_int("CAL_ACC0_ID", 1);
-    mParamServer->provide_param_int("CAL_GYRO0_ID", 1);
-    mParamServer->provide_param_int("CAL_MAG0_ID", 1);
-    mParamServer->provide_param_int("SYS_HITL", 0);
-    mParamServer->provide_param_int("MIS_TAKEOFF_ALT", 0);
+    mParameterServer.reset(new ParameterServer(serverComponent));
 
     // Allow the vehicle to change to auto mode (manual is always allowed) and arm, disable takeoff (only rover support for now)
     mActionServer->set_allowable_flight_modes({true, false, false});
@@ -73,7 +64,7 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         mTelemetryServer->publish_home(homePositionLlh);
         mTelemetryServer->publish_position_velocity_ned(positionVelocityNed);
         mTelemetryServer->publish_raw_gps(mRawGps, mGpsInfo);
-    });
+    });    
 
     mActionServer->subscribe_flight_mode_change([this](mavsdk::ActionServer::Result res, mavsdk::ActionServer::FlightMode mode) {
         if  (res == mavsdk::ActionServer::Result::Success) {
@@ -238,7 +229,7 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         });
     });
 
-    mMavsdk.intercept_outgoing_messages_async([](mavlink_message_t &message){
+    mMavsdk.intercept_outgoing_messages_async([this](mavlink_message_t &message){
         switch (message.msgid) {
         case MAVLINK_MSG_ID_HEARTBEAT: // Fix some info in heartbeat s.th. MAVSDK / ControlTower detects vehicle correctly
             mavlink_heartbeat_t heartbeat;
@@ -256,6 +247,11 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
 //                        autopilot_version.os_sw_version << autopilot_version.board_version << autopilot_version.flight_custom_version << autopilot_version.middleware_custom_version <<
 //                        autopilot_version.os_custom_version << autopilot_version.vendor_id << autopilot_version.product_id << autopilot_version.uid << autopilot_version.uid2;
 //            break;
+        case MAVLINK_MSG_ID_PARAM_VALUE: // This message is sent when a parameter has been changed
+            mavlink_param_value_t parameter;
+            mavlink_msg_param_value_decode(&message, &parameter);
+            if (parameter.param_type == 9) // Float
+                mParameterServer->updateParameter(parameter.param_id, parameter.param_value);
         default: ;
 //            qDebug() << "out:" << message.msgid;
         }
@@ -407,30 +403,7 @@ void MavsdkVehicleServer::sendGpsOriginLlh(const llh_t &gpsOriginLlh)
         qDebug() << "Warning: could not send GPS_GLOBAL_ORIGIN via MAVLINK.";
 };
 
-void MavsdkVehicleServer::saveParametersToXmlFile()
+QSharedPointer<ParameterServer> MavsdkVehicleServer::getParameterServer()
 {
-    mavsdk::ParamServer::AllParams parameters = mParamServer->retrieve_all_params();
-    QFile parameterFile("vehicle_parameters.xml");
-
-    if (!parameterFile.open(QIODevice::WriteOnly))
-        qDebug() << "Could not save parameters";
-
-    QXmlStreamWriter stream(&parameterFile);
-    stream.setCodec("UTF-8");
-    stream.setAutoFormatting(true);
-    stream.writeStartDocument();
-
-    for (const auto& vehicleParameter : parameters.int_params) {
-        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
-    }
-    for (const auto& vehicleParameter : parameters.float_params) {
-        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
-    }
-    for (const auto& vehicleParameter : parameters.custom_params) {
-        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::fromStdString(vehicleParameter.value));
-    }
-
-    stream.writeEndElement();
-    stream.writeEndDocument();
-    parameterFile.close();
-};
+    return mParameterServer;
+}

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -14,7 +14,6 @@
 #include <mavsdk/plugins/action_server/action_server.h>
 #include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
 #include <mavsdk/plugins/mission_raw_server/mission_raw_server.h>
-#include <mavsdk/plugins/param_server/param_server.h>
 #include <mavsdk/plugins/telemetry_server/telemetry_server.h>
 #include <mavsdk/server_component.h>
 #include "autopilot/waypointfollower.h"
@@ -22,6 +21,7 @@
 #include "vehicles/controller/movementcontroller.h"
 #include "vehicles/vehiclestate.h"
 #include "waywise.h"
+#include "communication/parameterserver.h"
 
 class MavsdkVehicleServer : public QObject
 {
@@ -34,9 +34,7 @@ public:
     void setManualControlMaxSpeed(double manualControlMaxSpeed_ms);
     void mavResult(const uint16_t command, MAV_RESULT result);
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh);
-
-public slots:
-    void saveParametersToXmlFile();
+    QSharedPointer<ParameterServer> getParameterServer();
 
 signals:
     void startWaypointFollower(bool fromBeginning); // to enable starting from MAVSDK thread
@@ -55,7 +53,6 @@ private:
     mavsdk::TelemetryServer::RawGps mRawGps;
     mavsdk::TelemetryServer::GpsInfo mGpsInfo {0, mavsdk::TelemetryServer::FixType::NoGps};
     std::shared_ptr<mavsdk::ActionServer> mActionServer;
-    std::shared_ptr<mavsdk::ParamServer> mParamServer;
     std::shared_ptr<mavsdk::MissionRawServer> mMissionRawServer;
     std::shared_ptr<mavsdk::MavlinkPassthrough> mMavlinkPassthrough;
     QTimer mPublishMavlinkTimer;
@@ -64,6 +61,7 @@ private:
     QSharedPointer<UbloxRover> mUbloxRover;
     QSharedPointer<WaypointFollower> mWaypointFollower;
     QSharedPointer<MovementController> mMovementController;
+    QSharedPointer<ParameterServer> mParameterServer;
 
     bool mHeartbeat;
     QTimer mHeartbeatTimer;

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -21,7 +21,7 @@
 #include "vehicles/controller/movementcontroller.h"
 #include "vehicles/vehiclestate.h"
 #include "waywise.h"
-#include "communication/parameterserver.h"
+#include "communication/mavlinkparameterserver.h"
 
 class MavsdkVehicleServer : public QObject
 {

--- a/communication/parameterserver.cpp
+++ b/communication/parameterserver.cpp
@@ -1,0 +1,56 @@
+#include "parameterserver.h"
+#include <QXmlStreamWriter>
+#include <QFile>
+#include <QDebug>
+
+ParameterServer::ParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent)
+{
+    mMavsdkParamServer = new mavsdk::ParamServer(serverComponent);
+
+    // These are needed for MAVSDK at the moment
+    mMavsdkParamServer->provide_param_int("CAL_ACC0_ID", 1);
+    mMavsdkParamServer->provide_param_int("CAL_GYRO0_ID", 1);
+    mMavsdkParamServer->provide_param_int("CAL_MAG0_ID", 1);
+    mMavsdkParamServer->provide_param_int("SYS_HITL", 0);
+    mMavsdkParamServer->provide_param_int("MIS_TAKEOFF_ALT", 0);
+}
+
+void ParameterServer::updateParameter(std::string parameterName, float parameterValue)
+{
+    auto setParameterFunction = mParameterToClassMapping.find(parameterName)->second.first;
+    setParameterFunction(parameterValue);
+}
+
+void ParameterServer::provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction)
+{
+    mParameterToClassMapping.insert_or_assign(parameterName, std::make_pair(setClassParameterFunction, getClassParameterFunction));
+    mMavsdkParamServer->provide_param_float(parameterName, getClassParameterFunction());
+};
+
+void ParameterServer::saveParametersToXmlFile()
+{
+    mavsdk::ParamServer::AllParams parameters = mMavsdkParamServer->retrieve_all_params();
+    QFile parameterFile("vehicle_parameters.xml");
+
+    if (!parameterFile.open(QIODevice::WriteOnly))
+        qDebug() << "Could not save parameters";
+
+    QXmlStreamWriter stream(&parameterFile);
+    stream.setCodec("UTF-8");
+    stream.setAutoFormatting(true);
+    stream.writeStartDocument();
+
+    for (const auto& vehicleParameter : parameters.int_params) {
+        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
+    }
+    for (const auto& vehicleParameter : parameters.float_params) {
+        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
+    }
+    for (const auto& vehicleParameter : parameters.custom_params) {
+        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::fromStdString(vehicleParameter.value));
+    }
+
+    stream.writeEndElement();
+    stream.writeEndDocument();
+    parameterFile.close();
+};

--- a/communication/parameterserver.cpp
+++ b/communication/parameterserver.cpp
@@ -1,56 +1,11 @@
+/*
+ *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ */
 #include "parameterserver.h"
-#include <QXmlStreamWriter>
-#include <QFile>
-#include <QDebug>
-
-ParameterServer::ParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent)
-{
-    mMavsdkParamServer = new mavsdk::ParamServer(serverComponent);
-
-    // These are needed for MAVSDK at the moment
-    mMavsdkParamServer->provide_param_int("CAL_ACC0_ID", 1);
-    mMavsdkParamServer->provide_param_int("CAL_GYRO0_ID", 1);
-    mMavsdkParamServer->provide_param_int("CAL_MAG0_ID", 1);
-    mMavsdkParamServer->provide_param_int("SYS_HITL", 0);
-    mMavsdkParamServer->provide_param_int("MIS_TAKEOFF_ALT", 0);
-}
 
 void ParameterServer::updateParameter(std::string parameterName, float parameterValue)
 {
     auto setParameterFunction = mParameterToClassMapping.find(parameterName)->second.first;
     setParameterFunction(parameterValue);
 }
-
-void ParameterServer::provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction)
-{
-    mParameterToClassMapping.insert_or_assign(parameterName, std::make_pair(setClassParameterFunction, getClassParameterFunction));
-    mMavsdkParamServer->provide_param_float(parameterName, getClassParameterFunction());
-};
-
-void ParameterServer::saveParametersToXmlFile()
-{
-    mavsdk::ParamServer::AllParams parameters = mMavsdkParamServer->retrieve_all_params();
-    QFile parameterFile("vehicle_parameters.xml");
-
-    if (!parameterFile.open(QIODevice::WriteOnly))
-        qDebug() << "Could not save parameters";
-
-    QXmlStreamWriter stream(&parameterFile);
-    stream.setCodec("UTF-8");
-    stream.setAutoFormatting(true);
-    stream.writeStartDocument();
-
-    for (const auto& vehicleParameter : parameters.int_params) {
-        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
-    }
-    for (const auto& vehicleParameter : parameters.float_params) {
-        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::number(vehicleParameter.value));
-    }
-    for (const auto& vehicleParameter : parameters.custom_params) {
-        stream.writeTextElement(QString::fromStdString(vehicleParameter.name), QString::fromStdString(vehicleParameter.value));
-    }
-
-    stream.writeEndElement();
-    stream.writeEndDocument();
-    parameterFile.close();
-};

--- a/communication/parameterserver.h
+++ b/communication/parameterserver.h
@@ -1,22 +1,41 @@
+/*
+ *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 #ifndef PARAMETERSERVER_H
 #define PARAMETERSERVER_H
 
 #include <QObject>
-#include <mavsdk/server_component.h>
-#include <mavsdk/plugins/param_server/param_server.h>
-#include <unordered_map>
 
 class ParameterServer : public QObject
 {
     Q_OBJECT
 public:
-    explicit ParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
-    void updateParameter(std::string parameterName, float parameterValue);
-    void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction);
-    void saveParametersToXmlFile();
+    struct IntParameter {
+        std::string name{};
+        int32_t value{};
+    };
+    struct FloatParameter {
+        std::string name{};
+        float value{};
+    };
+    struct CustomParameter {
+        std::string name{};
+        std::string value{};
+    };
+    struct AllParameters {
+        std::vector<IntParameter> intParameters{};
+        std::vector<FloatParameter> floatParameters{};
+        std::vector<CustomParameter> customParameters{};
+    };
 
-private:
-    mavsdk::ParamServer *mMavsdkParamServer;
+    void updateParameter(std::string parameterName, float parameterValue);
+
+    virtual void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction) = 0;
+    virtual void saveParametersToXmlFile() = 0;
+
+protected:
     std::unordered_map<std::string, std::pair<std::function<void(float)>, std::function<float(void)>>> mParameterToClassMapping;
 };
 

--- a/communication/parameterserver.h
+++ b/communication/parameterserver.h
@@ -1,0 +1,23 @@
+#ifndef PARAMETERSERVER_H
+#define PARAMETERSERVER_H
+
+#include <QObject>
+#include <mavsdk/server_component.h>
+#include <mavsdk/plugins/param_server/param_server.h>
+#include <unordered_map>
+
+class ParameterServer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
+    void updateParameter(std::string parameterName, float parameterValue);
+    void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction);
+    void saveParametersToXmlFile();
+
+private:
+    mavsdk::ParamServer *mMavsdkParamServer;
+    std::unordered_map<std::string, std::pair<std::function<void(float)>, std::function<float(void)>>> mParameterToClassMapping;
+};
+
+#endif // PARAMETERSERVER_H


### PR DESCRIPTION
…all updateParameter when ControlTower has changed a parameter

Mavlink parameter protocol states that whenever a parameter changes, the current value of the parameter should be broadcasted with message PARAM_VALUE
https://mavlink.io/en/services/parameter.html#:~:text=or%20whenever%20a%20parameter%20is%20set%20(PARAM_SET)%20or%20changes.
We now listen for this message with mMavsdk.intercept_outgoing_messages_async, and then call mParameterServer->updateParameter