### PR TITLE
MultiWaypointFollower: added parameter functions

### DIFF
--- a/autopilot/multiwaypointfollower.cpp
+++ b/autopilot/multiwaypointfollower.cpp
@@ -60,6 +60,49 @@ void MultiWaypointFollower::resetState()
     mWayPointFollowerList[mWaypointFollowerID]->resetState();
 }
 
+double MultiWaypointFollower::getPurePursuitRadius() const
+{
+    if (qSharedPointerDynamicCast<PurepursuitWaypointFollower>(mWayPointFollowerList[mWaypointFollowerID]).get())
+        return qSharedPointerCast<PurepursuitWaypointFollower>(mWayPointFollowerList[mWaypointFollowerID])->getPurePursuitRadius();
+    else
+        return 0;
+}
+
+void MultiWaypointFollower::setPurePursuitRadius(double value)
+{
+    for (const auto &wayPointFollower : mWayPointFollowerList)
+        if(qSharedPointerDynamicCast<PurepursuitWaypointFollower>(wayPointFollower))
+            qSharedPointerCast<PurepursuitWaypointFollower>(wayPointFollower)->setPurePursuitRadius(value);
+        else
+            qDebug() << "WaypointFollower has no function named setPurePursuitRadius";
+}
+
+void MultiWaypointFollower::setAdaptivePurePursuitRadiusActive(bool adaptive)
+{
+    for (const auto &wayPointFollower : mWayPointFollowerList)
+        if(qSharedPointerDynamicCast<PurepursuitWaypointFollower>(wayPointFollower))
+            qSharedPointerCast<PurepursuitWaypointFollower>(wayPointFollower)->setAdaptivePurePursuitRadiusActive(adaptive);
+        else
+            qDebug() << "WaypointFollower has no function named setAdaptivePurePursuitRadiusActive";
+}
+
+double MultiWaypointFollower::getAdaptivePurePursuitRadiusCoefficient()
+{
+    if (qSharedPointerDynamicCast<PurepursuitWaypointFollower>(mWayPointFollowerList[mWaypointFollowerID]).get())
+        return qSharedPointerCast<PurepursuitWaypointFollower>(mWayPointFollowerList[mWaypointFollowerID])->getAdaptivePurePursuitRadiusCoefficient();
+    else
+        return 0;
+}
+
+void MultiWaypointFollower::setAdaptivePurePursuitRadiusCoefficient(double coefficient)
+{
+    for (const auto &wayPointFollower : mWayPointFollowerList)
+        if(qSharedPointerDynamicCast<PurepursuitWaypointFollower>(wayPointFollower))
+            qSharedPointerCast<PurepursuitWaypointFollower>(wayPointFollower)->setAdaptivePurePursuitRadiusCoefficient(coefficient);
+        else
+            qDebug() << "WaypointFollower has no function named setAdaptivePurePursuitRadiusCoefficient";
+}
+
 int MultiWaypointFollower::addWaypointFollower(QSharedPointer<WaypointFollower> waypointfollower)
 {
     mWayPointFollowerList.append(waypointfollower);

--- a/autopilot/multiwaypointfollower.h
+++ b/autopilot/multiwaypointfollower.h
@@ -34,6 +34,13 @@ public:
     virtual void stop() override;
     virtual void resetState() override;
 
+    // PurepursuitWaypointFollower parameters
+    double getPurePursuitRadius() const;
+    void setPurePursuitRadius(double value);
+    void setAdaptivePurePursuitRadiusActive(bool adaptive);
+    double getAdaptivePurePursuitRadiusCoefficient();
+    void setAdaptivePurePursuitRadiusCoefficient(double coefficient);
+
     int addWaypointFollower(QSharedPointer<WaypointFollower> waypointfollower);
     void setActiveWaypointFollower(int waypointfollowerID);
     QSharedPointer<WaypointFollower> getActiveWaypointFollower();


### PR DESCRIPTION
Added functions that set parameters on all waypointfollowers inside multiwaypointfollower. Pointers to these functions are passed into provideParameter() as in https://github.com/RISE-Dependable-Transport-Systems/MacTrac/commit/6ce455a07bdda02172bd7a75d0d0250708454ff0