### PR TITLE
feature/logger

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -435,7 +435,7 @@ void MavsdkVehicleServer::on_logSent(const QString& message, const quint8& sever
         const int chunkSize = MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN - 8; // STATUSTEXT supports up to char[50], -8 adjustment to fit MAVLink header
         int numChunks = (item.log.length() + chunkSize - 1) / chunkSize;
 
-        if(item.log.length() % 42 == 0)  // need extra message for null terminator, so to not overwrite any message character
+        if(item.log.length() % chunkSize == 0)  // need extra message for null terminator, so to not overwrite any message character
             numChunks++;
 
         for(int chunkIndex = 0; chunkIndex < numChunks; chunkIndex++) {
@@ -450,7 +450,7 @@ void MavsdkVehicleServer::on_logSent(const QString& message, const quint8& sever
             qstrcpy(statusText.text, chunkBytes.constData());
 
             if(chunkIndex == numChunks - 1)
-                statusText.text[49] = '\0'; // ensure null terminated
+                statusText.text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN - 1] = '\0'; // ensure null terminated
 
             if(numChunks > 1)
                 statusText.id = idCounter;
@@ -466,7 +466,7 @@ void MavsdkVehicleServer::on_logSent(const QString& message, const quint8& sever
                 qWarning() << "Could not send log output via MAVLINK.";
         }
 
-        if(idCounter == 65535)  // overflow avoidance
+        if(idCounter == std::numeric_limits<typeof idCounter>::max())  // overflow avoidance
             idCounter = 1;
         else
             idCounter++;

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -10,7 +10,6 @@
 #include <QMetaMethod>
 #include <algorithm>
 #include <chrono>
-#include <QMetaType>
 #include "WayWise/logger/logger.h"
 
 MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState)

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -10,9 +10,14 @@
 #include <QMetaMethod>
 #include <algorithm>
 #include <chrono>
+#include <QMetaType>
+#include "WayWise/logger/logger.h"
 
 MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState)
 {
+    qRegisterMetaType<uint8_t>("uint8_t");
+    connect(&Logger::getInstance(), &Logger::logSentVehicle, this, &MavsdkVehicleServer::on_logSent);
+
     mVehicleState = vehicleState;
 
     mavsdk::Mavsdk::Configuration configuration(mavsdk::Mavsdk::Configuration::UsageType::Autopilot);
@@ -403,3 +408,78 @@ void MavsdkVehicleServer::sendGpsOriginLlh(const llh_t &gpsOriginLlh)
     if (mMavlinkPassthrough->send_message(mavGpsGlobalOriginMsg) != mavsdk::MavlinkPassthrough::Result::Success)
         qDebug() << "Warning: could not send GPS_GLOBAL_ORIGIN via MAVLINK.";
 };
+
+void MavsdkVehicleServer::on_logSent(const QString& message, const uint8_t& severity)
+{
+    struct logQueueItem {
+        QString log;
+        uint16_t id;
+        uint8_t severity;
+    };
+
+    static QVector<logQueueItem> logQueue;
+
+    if (mMavlinkPassthrough == nullptr) {
+        logQueueItem item;
+
+        item.log = message;
+        item.severity = severity;
+
+        logQueue.push_back(item);
+
+        return;
+    }
+
+    if(!logQueue.isEmpty()) {
+        for(const logQueueItem &item : logQueue)
+            sendStatusText(item.log, item.severity);
+
+        logQueue.clear();
+    }
+
+    sendStatusText(message, severity);
+}
+
+void MavsdkVehicleServer::sendStatusText(const QString& message, const uint8_t& severity) {
+
+    static uint16_t idCounter = 1;
+
+    const int chunkSize = MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN - 8; // STATUSTEXT supports up to char[50], -8 adjustment to fit MAVLink header
+    int numChunks = (message.length() + chunkSize - 1) / chunkSize;
+
+    if(message.length() % 42 == 0)  // need extra message for null terminator, so to not overwrite any message character
+        numChunks++;
+
+    for(int chunkIndex = 0; chunkIndex < numChunks; chunkIndex++) {
+        QString chunk = message.mid(chunkIndex * chunkSize, chunkSize);
+        QByteArray chunkBytes = chunk.toUtf8();
+
+        mavlink_statustext_t statusText;    // send text messages to ground-station or other MAVLink-enabled systems
+        memset(&statusText, 1, sizeof(statusText));
+
+        statusText.severity = severity;
+
+        qstrcpy(statusText.text, chunkBytes.constData());
+
+        if(chunkIndex == numChunks - 1)
+            statusText.text[49] = '\0'; // ensure null terminated
+
+        if(numChunks > 1)
+            statusText.id = idCounter;
+        else
+            statusText.id = 0;  // message can be omitted directly
+
+        statusText.chunk_seq = chunkIndex;
+
+        mavlink_message_t mavLogMsg;
+        mavlink_msg_statustext_encode(mMavlinkPassthrough->get_our_sysid(), mMavlinkPassthrough->get_our_compid(), &mavLogMsg, &statusText);
+
+        if (mMavlinkPassthrough->send_message(mavLogMsg) != mavsdk::MavlinkPassthrough::Result::Success)
+            qWarning() << "Could not send log output via MAVLINK.";
+    }
+
+    if(idCounter == 65535)  // overflow avoidance
+        idCounter = 1;
+    else
+        idCounter++;
+}

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -34,6 +34,8 @@ public:
     void setManualControlMaxSpeed(double manualControlMaxSpeed_ms);
     void mavResult(const uint16_t command, MAV_RESULT result);
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh);
+    void on_logSent(const QString& message, const uint8_t& severity);
+    void sendStatusText(const QString& message, const uint8_t& severity);
 
 signals:
     void startWaypointFollower(bool fromBeginning); // to enable starting from MAVSDK thread

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -34,8 +34,7 @@ public:
     void setManualControlMaxSpeed(double manualControlMaxSpeed_ms);
     void mavResult(const uint16_t command, MAV_RESULT result);
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh);
-    void on_logSent(const QString& message, const uint8_t& severity);
-    void sendStatusText(const QString& message, const uint8_t& severity);
+    void on_logSent(const QString& message, const quint8& severity);
 
 signals:
     void startWaypointFollower(bool fromBeginning); // to enable starting from MAVSDK thread

--- a/communication/vehicleconnections/mavsdkvehicleconnection.h
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.h
@@ -89,6 +89,7 @@ private:
 
     mavsdk::MissionRaw::MissionItem convertPosPointToMissionItem(const PosPoint& posPoint, int sequenceId, bool current = false);
     VehicleConnection::Result convertResult(mavsdk::Param::Result result) const;
+    void outputLogMessage(QString logMessage, uint8_t severity) const;
 
     // VehicleConnection interface
 protected:

--- a/communication/vehicleconnections/mavsdkvehicleconnection.h
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.h
@@ -89,7 +89,6 @@ private:
 
     mavsdk::MissionRaw::MissionItem convertPosPointToMissionItem(const PosPoint& posPoint, int sequenceId, bool current = false);
     VehicleConnection::Result convertResult(mavsdk::Param::Result result) const;
-    void outputLogMessage(QString logMessage, uint8_t severity) const;
 
     // VehicleConnection interface
 protected:

--- a/logger/logger.cpp
+++ b/logger/logger.cpp
@@ -1,0 +1,159 @@
+/*
+ *  Author: Aria Mirzai, aria.mirzai@ri.se (2023)
+ */
+
+#include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <mavsdk/mavsdk.h>
+#include <QStandardPaths>
+#include "logger.h"
+
+QFile* Logger::logFile = Q_NULLPTR;
+bool Logger::isInit = false;
+
+Logger::Logger(QObject *parent)
+    : QObject{parent}
+{
+
+}
+
+Logger::~Logger()
+{
+    if(logFile != Q_NULLPTR) {
+        logFile->close();
+        delete logFile;
+    }
+
+    qInstallMessageHandler(0);  // detach qInstallMessageHandler
+}
+
+void Logger::initGroundStation()
+{
+    if(isInit)  return;
+
+    QDir documentsDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));   // Documents directory (OS agnostic)
+
+    QString folderName = "ControlTower Logs";
+    QString folderPath = documentsDirectory.filePath(folderName);
+
+    if (!documentsDirectory.exists(folderPath))
+    {
+        if (documentsDirectory.mkdir(folderPath))   qDebug() << "Logs folder created";
+        else                                        qDebug() << "Failed to create Logs folder.";
+    }
+
+    logFile = new QFile;
+
+    QString fileName = QString("%1/Log %2.log").arg(folderPath).arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss"));
+
+    logFile->setFileName(fileName);
+    logFile->open(QIODevice::Append | QIODevice::Text);
+
+    qInstallMessageHandler(Logger::messageOutputGroundStation);
+
+    Logger::isInit = true;
+}
+
+void Logger::initVehicle()
+{
+    if(isInit)  return;
+
+    qInstallMessageHandler(Logger::messageOutputVehicle);
+
+    Logger::isInit = true;
+}
+
+void Logger::messageOutputGroundStation(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    QString log;
+
+    switch (type) {
+    case QtDebugMsg:
+        log = QObject::tr("%1 | Debug: %3").arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss")).arg(qPrintable(msg));
+        break;
+    case QtInfoMsg:
+        log = QObject::tr("%1 | Info: %3").arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss")).arg(qPrintable(msg));
+        break;
+    case QtWarningMsg:
+        log = QObject::tr("%1 | Warning: %3").arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss")).arg(qPrintable(msg));
+        break;
+    case QtCriticalMsg:
+        log = QObject::tr("%1 | Critical: %3").arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss")).arg(qPrintable(msg));
+        break;
+    case QtFatalMsg:
+        log = QObject::tr("%1 | Fatal: %3").arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss")).arg(qPrintable(msg));
+        break;
+    }
+
+    fprintf(stderr, "%s\n", qPrintable(log));
+
+    static QStringList logQueue;
+
+    if(Logger::getInstance().isConnectedGroundStation()) {
+        if(!logQueue.empty())
+            for(const QString &log : logQueue)
+                Logger::getInstance().emit logSentGroundStation(log);
+
+        logQueue.clear();
+
+        Logger::getInstance().emit logSentGroundStation(log);
+    } else
+        logQueue.append(log);
+
+    log.append("\n");
+    logFile->write(log.toLocal8Bit());
+    logFile->flush();
+}
+
+void Logger::messageOutputVehicle(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    uint8_t msgSeverity;
+
+    switch (type) {
+    case QtDebugMsg:
+        msgSeverity = MAV_SEVERITY_DEBUG;
+        fprintf(stderr, "Debug: %s\n", qPrintable(msg));
+        break;
+    case QtInfoMsg:
+        msgSeverity = MAV_SEVERITY_INFO;
+        fprintf(stderr, "Info: %s\n", qPrintable(msg));
+        break;
+    case QtWarningMsg:
+        msgSeverity = MAV_SEVERITY_WARNING;
+        fprintf(stderr, "Warning: %s\n", qPrintable(msg));
+        break;
+    case QtCriticalMsg:
+        msgSeverity = MAV_SEVERITY_CRITICAL;
+        fprintf(stderr, "Critical: %s\n", qPrintable(msg));
+        break;
+    case QtFatalMsg:
+        msgSeverity = MAV_SEVERITY_EMERGENCY;
+        fprintf(stderr, "Fatal: %s\n", qPrintable(msg));
+        break;
+    }
+
+    struct logQueueItem {
+        QString log;
+        uint8_t severity;
+    };
+
+    static QVector<logQueueItem> logQueue;
+
+    if(Logger::getInstance().isConnectedVehicle()) {
+        if(!logQueue.isEmpty())
+            for(const logQueueItem &item : logQueue)
+                Logger::getInstance().emit logSentVehicle(item.log, item.severity);
+
+        logQueue.clear();
+
+        Logger::getInstance().emit logSentVehicle(msg, msgSeverity);
+    } else {
+        logQueueItem item;
+
+        item.log = msg;
+        item.severity = msgSeverity;
+
+        logQueue.push_back(item);
+    }
+}

--- a/logger/logger.cpp
+++ b/logger/logger.cpp
@@ -45,7 +45,7 @@ void Logger::initGroundStation()
 
     logFile = new QFile;
 
-    QString fileName = QString("%1/Log %2.log").arg(folderPath).arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh:mm:ss"));
+    QString fileName = QString("%1/Log %2.log").arg(folderPath).arg(QDateTime::currentDateTime().toString("dd-MM-yyyy hh-mm-ss"));
 
     logFile->setFileName(fileName);
     logFile->open(QIODevice::Append | QIODevice::Text);

--- a/logger/logger.cpp
+++ b/logger/logger.cpp
@@ -51,7 +51,7 @@ void Logger::initGroundStation()
 
     if (!documentsDirectory.exists(folderPath))
     {
-        if (documentsDirectory.mkdir(folderPath))   qDebug() << "Logs folder created";
+        if (documentsDirectory.mkpath(folderPath))   qDebug() << "Logs folder created";
         else                                        qDebug() << "Failed to create Logs folder.";
     }
 

--- a/logger/logger.h
+++ b/logger/logger.h
@@ -1,0 +1,54 @@
+/*
+ *  Author: Aria Mirzai, aria.mirzai@ri.se (2023)
+ */
+
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <QObject>
+#include <QMetaMethod>
+#include <QFile>
+
+class Logger : public QObject {
+    Q_OBJECT
+public:
+    static Logger& getInstance()
+    {
+        static Logger instance;
+        return instance;
+    }
+
+    bool isConnectedGroundStation() {
+        static const QMetaMethod logSentSignal = QMetaMethod::fromSignal(&Logger::logSentGroundStation);
+        return isSignalConnected(logSentSignal);
+    }
+
+    bool isConnectedVehicle() {
+        static const QMetaMethod logSentSignal = QMetaMethod::fromSignal(&Logger::logSentVehicle);
+        return isSignalConnected(logSentSignal);
+    }
+
+    static void initGroundStation();
+
+    static void initVehicle();
+
+    static void messageOutputGroundStation(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+
+    static void messageOutputVehicle(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+
+private:
+    explicit Logger(QObject *parent = nullptr);
+
+    ~Logger();
+
+    static QFile* logFile;
+
+    static bool isInit;
+
+signals:
+    void logSentGroundStation(const QString& message);
+
+    void logSentVehicle(const QString& message, const uint8_t& severity);
+};
+
+#endif // LOGGER_H

--- a/logger/logger.h
+++ b/logger/logger.h
@@ -12,29 +12,15 @@
 class Logger : public QObject {
     Q_OBJECT
 public:
-    static Logger& getInstance()
-    {
-        static Logger instance;
-        return instance;
-    }
+    static Logger& getInstance();
 
-    bool isConnectedGroundStation() {
-        static const QMetaMethod logSentSignal = QMetaMethod::fromSignal(&Logger::logSentGroundStation);
-        return isSignalConnected(logSentSignal);
-    }
-
-    bool isConnectedVehicle() {
-        static const QMetaMethod logSentSignal = QMetaMethod::fromSignal(&Logger::logSentVehicle);
-        return isSignalConnected(logSentSignal);
-    }
+    bool isConnected();
 
     static void initGroundStation();
 
     static void initVehicle();
 
-    static void messageOutputGroundStation(QtMsgType type, const QMessageLogContext& context, const QString& msg);
-
-    static void messageOutputVehicle(QtMsgType type, const QMessageLogContext& context, const QString& msg);
+    static void messageOutput(QtMsgType type, const QMessageLogContext& context, const QString& msg);
 
 private:
     explicit Logger(QObject *parent = nullptr);
@@ -46,9 +32,7 @@ private:
     static bool isInit;
 
 signals:
-    void logSentGroundStation(const QString& message);
-
-    void logSentVehicle(const QString& message, const uint8_t& severity);
+    void logSent(const QString& message, const quint8& severity);
 };
 
 #endif // LOGGER_H


### PR DESCRIPTION
- Issue with log file naming on Windows fixed, ":" replaced with "-"
- Logger is now a thread-safe singleton, which eliminates the need for a relay-class.
- Both the ground-station and vehicles now use the same Logger class.
- The log file is now written to during runtime, so logs are not lost in case of crash.
- Statustext messages are now implemented according to the MAVLink documentation guidelines, which allows messages to be sorted into the correct order upon arrival.