### PR TITLE
ParameterServer: now a Singleton

### DIFF
--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -3,15 +3,21 @@
  *               2021 Rickard Häll      rickard.hall@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
-#include "purepursuitwaypointfollower.h"
 #include <cmath>
 #include <QDebug>
 #include <QLineF>
+#include "purepursuitwaypointfollower.h"
+#include "WayWise/communication/parameterserver.h"
 
 PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<MovementController> movementController)
 {
     mMovementController = movementController;
     connect(&mUpdateStateTimer, &QTimer::timeout, this, &PurepursuitWaypointFollower::updateState);
+
+    // Provide system parameters to ControlTower
+    ParameterServer::getInstance()->provideParameter("PPRadius", std::bind(&PurepursuitWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getPurePursuitRadius, this));
+    ParameterServer::getInstance()->provideParameter("APPRC", std::bind(&PurepursuitWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+
 
     // Follow point requires continuous updates of the point to follow
     mCurrentState.followPointTimedOut = true;

--- a/communication/mavlinkparameterserver.h
+++ b/communication/mavlinkparameterserver.h
@@ -1,3 +1,8 @@
+/*
+ *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
 #ifndef MAVLINKPARAMETERSERVER_H
 #define MAVLINKPARAMETERSERVER_H
 
@@ -10,9 +15,13 @@ class MavlinkParameterServer : public ParameterServer
 {
     Q_OBJECT
 public:
-    explicit MavlinkParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
+    static void initialize(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
     virtual void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction) override;
-    virtual void saveParametersToXmlFile() override;
+    virtual void saveParametersToXmlFile(QString filename) override;
+
+protected:
+    MavlinkParameterServer(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
+    ~MavlinkParameterServer(){};
 
 private:
     mavsdk::ParamServer *mMavsdkParamServer;

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -21,10 +21,11 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
     std::shared_ptr<mavsdk::ServerComponent> serverComponent = mMavsdk.server_component_by_type(mavsdk::Mavsdk::ServerComponentType::Autopilot);
 
     // Create server plugins
+    MavlinkParameterServer::initialize(serverComponent);
+    mParameterServer = MavlinkParameterServer::getInstance();
     mTelemetryServer.reset(new mavsdk::TelemetryServer(serverComponent));
     mActionServer.reset(new mavsdk::ActionServer(serverComponent));
     mMissionRawServer.reset(new mavsdk::MissionRawServer(serverComponent));
-    mParameterServer.reset(new MavlinkParameterServer(serverComponent));
 
     // Allow the vehicle to change to auto mode (manual is always allowed) and arm, disable takeoff (only rover support for now)
     mActionServer->set_allowable_flight_modes({true, false, false});
@@ -402,8 +403,3 @@ void MavsdkVehicleServer::sendGpsOriginLlh(const llh_t &gpsOriginLlh)
     if (mMavlinkPassthrough->send_message(mavGpsGlobalOriginMsg) != mavsdk::MavlinkPassthrough::Result::Success)
         qDebug() << "Warning: could not send GPS_GLOBAL_ORIGIN via MAVLINK.";
 };
-
-QSharedPointer<ParameterServer> MavsdkVehicleServer::getParameterServer()
-{
-    return mParameterServer;
-}

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -34,7 +34,6 @@ public:
     void setManualControlMaxSpeed(double manualControlMaxSpeed_ms);
     void mavResult(const uint16_t command, MAV_RESULT result);
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh);
-    QSharedPointer<ParameterServer> getParameterServer();
 
 signals:
     void startWaypointFollower(bool fromBeginning); // to enable starting from MAVSDK thread
@@ -61,7 +60,7 @@ private:
     QSharedPointer<UbloxRover> mUbloxRover;
     QSharedPointer<WaypointFollower> mWaypointFollower;
     QSharedPointer<MovementController> mMovementController;
-    QSharedPointer<ParameterServer> mParameterServer;
+    ParameterServer *mParameterServer;
 
     bool mHeartbeat;
     QTimer mHeartbeatTimer;

--- a/communication/parameterserver.cpp
+++ b/communication/parameterserver.cpp
@@ -2,10 +2,23 @@
  *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
+#include <QDebug>
 #include "parameterserver.h"
+
+ParameterServer* ParameterServer::mInstancePtr = nullptr;
+
+ParameterServer::ParameterServer() {};
+
+ParameterServer* ParameterServer::getInstance()
+{
+    if(!mInstancePtr)
+        qDebug() << "Parameter server object has not been created";
+    return mInstancePtr;
+}
 
 void ParameterServer::updateParameter(std::string parameterName, float parameterValue)
 {
+    const std::lock_guard<std::mutex> lock(mMutex);
     auto setParameterFunction = mParameterToClassMapping.find(parameterName)->second.first;
     setParameterFunction(parameterValue);
 }

--- a/communication/parameterserver.h
+++ b/communication/parameterserver.h
@@ -7,35 +7,22 @@
 #define PARAMETERSERVER_H
 
 #include <QObject>
+#include <mutex>
 
 class ParameterServer : public QObject
 {
     Q_OBJECT
 public:
-    struct IntParameter {
-        std::string name{};
-        int32_t value{};
-    };
-    struct FloatParameter {
-        std::string name{};
-        float value{};
-    };
-    struct CustomParameter {
-        std::string name{};
-        std::string value{};
-    };
-    struct AllParameters {
-        std::vector<IntParameter> intParameters{};
-        std::vector<FloatParameter> floatParameters{};
-        std::vector<CustomParameter> customParameters{};
-    };
-
+    static ParameterServer* getInstance();
     void updateParameter(std::string parameterName, float parameterValue);
-
     virtual void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction) = 0;
-    virtual void saveParametersToXmlFile() = 0;
+    virtual void saveParametersToXmlFile(QString filename) = 0;
 
 protected:
+    ParameterServer();
+    virtual ~ParameterServer(){};
+    static ParameterServer *mInstancePtr;
+    std::mutex mMutex;
     std::unordered_map<std::string, std::pair<std::function<void(float)>, std::function<float(void)>>> mParameterToClassMapping;
 };
 


### PR DESCRIPTION
Given that we need a mavsdk::ServerComponent in MavlinkParameterServer, I have put a createSingleton function there. createSingleton must be called before any call to ParameterServer::getInstance(), otherwise the program will crash with a qDebug() << "Parameter server object has not been created". 