### PR TITLE
check if currentRoute is empty before emitting

### DIFF
--- a/userinterface/planui.cpp
+++ b/userinterface/planui.cpp
@@ -69,7 +69,8 @@ void PlanUI::on_currentRouteSpinBox_valueChanged(int value)
 
 void PlanUI::on_sendToAutopilotButton_clicked()
 {
-    emit routeDoneForUse(mRoutePlanner->getCurrentRoute());
+    if(!mRoutePlanner->getCurrentRoute().isEmpty())
+        emit routeDoneForUse(mRoutePlanner->getCurrentRoute());
 }
 
 void PlanUI::on_heightSpinBox_valueChanged(double arg1)


### PR DESCRIPTION
This is a fix for the task "Send to Autopilot" crash