### PR TITLE
Fix pedantic warnings

### DIFF
--- a/communication/vehicleconnections/mavsdkvehicleconnection.cpp
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.cpp
@@ -128,10 +128,11 @@ MavsdkVehicleConnection::MavsdkVehicleConnection(std::shared_ptr<mavsdk::System>
     });
 
     mMavlinkPassthrough->subscribe_message(MAVLINK_MSG_ID_HEARTBEAT, [this](const mavlink_message_t &message) {
+        Q_UNUSED(message)
         emit gotHeartbeat(mSystem->get_system_id());
     });
 
-    mMavlinkPassthrough->subscribe_message(MAVLINK_MSG_ID_STATUSTEXT, [this](const mavlink_message_t &message)
+    mMavlinkPassthrough->subscribe_message(MAVLINK_MSG_ID_STATUSTEXT, [](const mavlink_message_t &message)
     {
         struct messageChunk {
             QString text;

--- a/sensors/gnss/ublox.cpp
+++ b/sensors/gnss/ublox.cpp
@@ -727,7 +727,12 @@ bool Ublox::ubloxCfgNmea(ubx_cfg_nmea *nmea)
 bool Ublox::ubloxCfgValset(unsigned char *values, int len,
                            bool ram, bool bbr, bool flash)
 {
-    uint8_t buffer[len + 4];
+    const size_t buffersize = 4096;
+    assert(((unsigned)len < buffersize) && "Ublox::ubloxCfgValset: message size exceeded");
+
+    uint8_t buffer[buffersize];
+    memset(&buffer, 0, buffersize);
+
     int ind = 0;
 
     ubx_put_U1(buffer, &ind, 0);
@@ -779,7 +784,12 @@ bool Ublox::ubloxCfgValset(unsigned char *values, int len,
  */
 bool Ublox::ubloxCfgValget(unsigned char *keys, int len, uint8_t layer, uint16_t position)
 {
-    uint8_t buffer[len + 4];
+    const size_t buffersize = 4096;
+    assert(((unsigned)len < buffersize) && "Ublox::ubloxCfgValset: message size exceeded");
+
+    uint8_t buffer[buffersize];
+    memset(&buffer, 0, buffersize);
+
     int ind = 0;
 
     ubx_put_U1(buffer, &ind, 0);

--- a/userinterface/map/mapwidget.cpp
+++ b/userinterface/map/mapwidget.cpp
@@ -817,9 +817,8 @@ void MapWidget::paint(QPainter &painter, int width, int height, bool highQuality
     drawOSMTiles(painter, drawTrans, viewWidth, viewHeight, viewCenter, highQuality);
     painter.restore();
 
-    double gridResolution;
     if (mDrawGrid)
-        gridResolution = drawGrid(painter, drawTrans, txtTrans, width, height);
+        drawGrid(painter, drawTrans, txtTrans, width, height);
 
     // Map module painting
     painter.save();

--- a/userinterface/map/mapwidget.h
+++ b/userinterface/map/mapwidget.h
@@ -47,12 +47,15 @@ class MapModule : public QObject
     Q_OBJECT
 public:
     virtual void processPaint(QPainter &painter, int width, int height, bool highQuality,
-                              QTransform drawTrans, QTransform txtTrans, double scale) { };
+                              QTransform drawTrans, QTransform txtTrans, double scale) {Q_UNUSED(painter) Q_UNUSED(width) Q_UNUSED(height) Q_UNUSED(highQuality) Q_UNUSED(drawTrans) Q_UNUSED(txtTrans) Q_UNUSED(scale)};
     virtual bool processMouse(bool isPress, bool isRelease, bool isMove, bool isWheel,
                               QPoint widgetPos, PosPoint mapPos, double wheelAngleDelta,
                               Qt::KeyboardModifiers keyboardModifiers,
-                              Qt::MouseButtons mouseButtons, double scale) { return false; };
-    virtual QSharedPointer<QMenu> populateContextMenu(const xyz_t& mapPos, const llh_t& enuReference) { return nullptr; };
+                              Qt::MouseButtons mouseButtons, double scale) {Q_UNUSED(isPress) Q_UNUSED(isRelease) Q_UNUSED(isMove) Q_UNUSED(isWheel) Q_UNUSED(widgetPos) Q_UNUSED(mapPos)
+                                                                            Q_UNUSED(wheelAngleDelta) Q_UNUSED(keyboardModifiers) Q_UNUSED(mouseButtons) Q_UNUSED(scale)
+                                                                            return false; };
+    virtual QSharedPointer<QMenu> populateContextMenu(const xyz_t& mapPos, const llh_t& enuReference) { Q_UNUSED(mapPos) Q_UNUSED(enuReference)
+                                                                                                        return nullptr;};
 
 signals:
     void requestRepaint();

--- a/userinterface/map/tracemodule.cpp
+++ b/userinterface/map/tracemodule.cpp
@@ -38,6 +38,8 @@ TraceModule::TraceModule()
 
 void TraceModule::processPaint(QPainter &painter, int width, int height, bool highQuality, QTransform drawTrans, QTransform txtTrans, double scale)
 {
+    Q_UNUSED(width) Q_UNUSED(height) Q_UNUSED(highQuality) Q_UNUSED(txtTrans)
+
     QPen pen;
     pen.setWidthF(7.5/scale);
     painter.setTransform(drawTrans);
@@ -57,11 +59,6 @@ void TraceModule::processPaint(QPainter &painter, int width, int height, bool hi
             }
         }
     }
-}
-
-bool TraceModule::processMouse(bool isPress, bool isRelease, bool isMove, bool isWheel, QPoint widgetPos, PosPoint mapPos, double wheelAngleDelta, Qt::KeyboardModifiers keyboardModifiers, Qt::MouseButtons mouseButtons, double scale)
-{
-    return false;
 }
 
 void TraceModule::setTraceActiveForPosType(PosType type, bool active)

--- a/userinterface/map/tracemodule.h
+++ b/userinterface/map/tracemodule.h
@@ -18,7 +18,6 @@ public:
 
     // MapModule interface
     virtual void processPaint(QPainter &painter, int width, int height, bool highQuality, QTransform drawTrans, QTransform txtTrans, double scale) override;
-    virtual bool processMouse(bool isPress, bool isRelease, bool isMove, bool isWheel, QPoint widgetPos, PosPoint mapPos, double wheelAngleDelta, Qt::KeyboardModifiers keyboardModifiers, Qt::MouseButtons mouseButtons, double scale) override;
 
     void setTraceActiveForPosType(PosType type, bool active);
     void setTraceColorForPosType(PosType type, QColor color);


### PR DESCRIPTION
This fixes all warnings when compiling RCCar and ControlTower with -Wall -Wextra -Wpedantic, which is common in ROS2 projects. Will add the following lines to CMakeLists.txt in our projects once this is merged:

```
set(CMAKE_C_STANDARD 23)
set(CMAKE_C_STANDARD_REQUIRED ON)

if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
  add_compile_options(-Wall -Wextra -Wpedantic)
endif()
```