### PR TITLE
CameraGimbalUI: check only for gamepads when gimbal is available, ask before capturing it

### DIFF
--- a/userinterface/cameragimbalui.cpp
+++ b/userinterface/cameragimbalui.cpp
@@ -16,6 +16,9 @@ CameraGimbalUI::CameraGimbalUI(QWidget *parent) :
     ui->videoWidget->installEventFilter(mVideoWidgetEventFilter.get());
 
     mSetRoiByClickOnMapModule = QSharedPointer<SetRoiByClickOnMapModule>::create(this);
+
+    // Ensure user interaction is performed in Qt thread
+    connect(this, &CameraGimbalUI::gotGimbal, this, &CameraGimbalUI::onGimbalReceived, Qt::ConnectionType::QueuedConnection);
 }
 
 CameraGimbalUI::~CameraGimbalUI()
@@ -26,84 +29,8 @@ CameraGimbalUI::~CameraGimbalUI()
 void CameraGimbalUI::setGimbal(const QSharedPointer<Gimbal> gimbal)
 {
     mGimbal = gimbal;
-    if (!gimbal.isNull()) {
-        ui->gimbalStatusLabel->setText("Gimbal found.");
-        ui->gimbalControlGroup->setEnabled(true);
-        ui->cameraControlGroup->setEnabled(true);
 
-        if (!QGamepadManager::instance()->connectedGamepads().isEmpty()) {
-            // Ask user whether gamepad should be used using Yes/No messagebox
-            askUseGamepadMessageBox.reset(new QMessageBox());
-            askUseGamepadMessageBox->setModal(false);
-
-            askUseGamepadMessageBox->setText("CameraGimbalUI: Gamepad detected");
-            askUseGamepadMessageBox->setInformativeText("A gamepad was detected: " + mGamepad->name() + ".\nShould it be used for controlling the vehicle's gimbal?");
-            askUseGamepadMessageBox->setIcon(QMessageBox::Information);
-
-            // We do not have any ownership over yesButton -> raw pointer
-            QPushButton* yesButton = askUseGamepadMessageBox->addButton(QMessageBox::Yes);
-            askUseGamepadMessageBox->addButton(QMessageBox::No);
-            askUseGamepadMessageBox->setDefaultButton(QMessageBox::No);
-
-            QObject::connect(askUseGamepadMessageBox.get(), &QMessageBox::buttonClicked, [this, yesButton](QAbstractButton *button) {
-                if (button == yesButton) {
-                    mGamepad = QSharedPointer<QGamepad>::create(QGamepadManager::instance()->connectedGamepads().first(), this);
-
-                    connect(&mGamepadTimer, &QTimer::timeout, [this]{
-                        double movePitchDeg = -4 * mGamepad->axisLeftY();
-                        double moveYawDeg = 4 * mGamepad->axisRightX();
-
-                        if (fabs(movePitchDeg) > 0.05 || fabs(moveYawDeg) > 0.05)
-                            moveGimbal(movePitchDeg, moveYawDeg);
-                    });
-                    mGamepadTimer.start(150);
-
-                    connect(mGamepad.get(), &QGamepad::buttonL1Changed, [this](bool value) {
-                        static bool valueWas = false;
-                        if (value && !valueWas)
-                            mVehicleConnection->setActuatorOutput(1, 0.0f);
-                        valueWas = value;
-                    });
-                    connect(mGamepad.get(), &QGamepad::buttonL2Changed, [this](bool value) {
-                        static bool valueWas = false;
-                        if (value && !valueWas)
-                            mVehicleConnection->setActuatorOutput(1, 1.0f);
-                        valueWas = value;
-                    });
-                    connect(mGamepad.get(), &QGamepad::buttonL3Changed, [this](bool value) {
-                        static bool valueWas = false;
-                        if (value && !valueWas)
-                            mVehicleConnection->setActuatorOutput(1, -1.0f);
-                        valueWas = value;
-                    });
-
-                    connect(mGamepad.get(), &QGamepad::buttonR1Changed, [this](bool value) {
-                        static bool valueWas = false;
-                        if (value && !valueWas)
-                            mVehicleConnection->setActuatorOutput(2, 0.0f);
-                        valueWas = value;
-                    });
-                    connect(mGamepad.get(), &QGamepad::buttonR2Changed, [this](bool value) {
-                        static bool valueWas = false;
-                        if (value && !valueWas)
-                            mVehicleConnection->setActuatorOutput(2, 1.0f);
-                        valueWas = value;
-                    });
-                    connect(mGamepad.get(), &QGamepad::buttonR3Changed, [this](bool value) {
-                        static bool valueWas = false;
-                        if (value && !valueWas)
-                            mVehicleConnection->setActuatorOutput(2, -1.0f);
-                        valueWas = value;
-                    });
-                    qDebug() << "CameraGimbalUI: gamepad captured.";
-                }
-            });
-
-            askUseGamepadMessageBox->show();
-            askUseGamepadMessageBox->raise();
-        } else
-            qDebug() << "CameraGimbalUI: not using any gamepad.";
-    }
+    emit gotGimbal();
 }
 
 QSharedPointer<MapModule> CameraGimbalUI::getSetRoiByClickOnMapModule() const
@@ -316,4 +243,86 @@ void CameraGimbalUI::on_streamDisconnectButton_clicked()
     mMediaPlayer->stop();
     ui->videoWidget->setFullScreen(false);
     ui->videoWidget->hide();
+}
+
+void CameraGimbalUI::onGimbalReceived()
+{
+    if (!mGimbal.isNull()) {
+        ui->gimbalStatusLabel->setText("Gimbal found.");
+        ui->gimbalControlGroup->setEnabled(true);
+        ui->cameraControlGroup->setEnabled(true);
+
+        if (!QGamepadManager::instance()->connectedGamepads().isEmpty()) {
+            // Ask user whether gamepad should be used using Yes/No messagebox
+            askUseGamepadMessageBox.reset(new QMessageBox());
+            askUseGamepadMessageBox->setModal(false);
+
+            askUseGamepadMessageBox->setText("CameraGimbalUI: Gamepad detected");
+            askUseGamepadMessageBox->setInformativeText("A gamepad was detected: " + mGamepad->name() + ".\nShould it be used for controlling the vehicle's gimbal?");
+            askUseGamepadMessageBox->setIcon(QMessageBox::Information);
+
+            // We do not have any ownership over yesButton -> raw pointer
+            QPushButton* yesButton = askUseGamepadMessageBox->addButton(QMessageBox::Yes);
+            askUseGamepadMessageBox->addButton(QMessageBox::No);
+            askUseGamepadMessageBox->setDefaultButton(QMessageBox::No);
+
+            QObject::connect(askUseGamepadMessageBox.get(), &QMessageBox::buttonClicked, [this, yesButton](QAbstractButton *button) {
+                if (button == yesButton) {
+                    mGamepad = QSharedPointer<QGamepad>::create(QGamepadManager::instance()->connectedGamepads().first(), this);
+
+                    connect(&mGamepadTimer, &QTimer::timeout, [this]{
+                        double movePitchDeg = -4 * mGamepad->axisLeftY();
+                        double moveYawDeg = 4 * mGamepad->axisRightX();
+
+                        if (fabs(movePitchDeg) > 0.05 || fabs(moveYawDeg) > 0.05)
+                            moveGimbal(movePitchDeg, moveYawDeg);
+                    });
+                    mGamepadTimer.start(150);
+
+                    connect(mGamepad.get(), &QGamepad::buttonL1Changed, [this](bool value) {
+                        static bool valueWas = false;
+                        if (value && !valueWas)
+                            mVehicleConnection->setActuatorOutput(1, 0.0f);
+                        valueWas = value;
+                    });
+                    connect(mGamepad.get(), &QGamepad::buttonL2Changed, [this](bool value) {
+                        static bool valueWas = false;
+                        if (value && !valueWas)
+                            mVehicleConnection->setActuatorOutput(1, 1.0f);
+                        valueWas = value;
+                    });
+                    connect(mGamepad.get(), &QGamepad::buttonL3Changed, [this](bool value) {
+                        static bool valueWas = false;
+                        if (value && !valueWas)
+                            mVehicleConnection->setActuatorOutput(1, -1.0f);
+                        valueWas = value;
+                    });
+
+                    connect(mGamepad.get(), &QGamepad::buttonR1Changed, [this](bool value) {
+                        static bool valueWas = false;
+                        if (value && !valueWas)
+                            mVehicleConnection->setActuatorOutput(2, 0.0f);
+                        valueWas = value;
+                    });
+                    connect(mGamepad.get(), &QGamepad::buttonR2Changed, [this](bool value) {
+                        static bool valueWas = false;
+                        if (value && !valueWas)
+                            mVehicleConnection->setActuatorOutput(2, 1.0f);
+                        valueWas = value;
+                    });
+                    connect(mGamepad.get(), &QGamepad::buttonR3Changed, [this](bool value) {
+                        static bool valueWas = false;
+                        if (value && !valueWas)
+                            mVehicleConnection->setActuatorOutput(2, -1.0f);
+                        valueWas = value;
+                    });
+                    qDebug() << "CameraGimbalUI: gamepad captured.";
+                }
+            });
+
+            askUseGamepadMessageBox->show();
+            askUseGamepadMessageBox->raise();
+        } else
+            qDebug() << "CameraGimbalUI: not using any gamepad.";
+    }
 }

--- a/userinterface/cameragimbalui.cpp
+++ b/userinterface/cameragimbalui.cpp
@@ -258,7 +258,8 @@ void CameraGimbalUI::onGimbalReceived()
             askUseGamepadMessageBox->setModal(false);
 
             askUseGamepadMessageBox->setText("CameraGimbalUI: Gamepad detected");
-            askUseGamepadMessageBox->setInformativeText("A gamepad was detected: " + mGamepad->name() + ".\nShould it be used for controlling the vehicle's gimbal?");
+            askUseGamepadMessageBox->setInformativeText("A gamepad was detected: " + QGamepadManager::instance()->gamepadName(QGamepadManager::instance()->connectedGamepads().first())
+                                                        + ".\nShould it be used for controlling the vehicle's gimbal?");
             askUseGamepadMessageBox->setIcon(QMessageBox::Information);
 
             // We do not have any ownership over yesButton -> raw pointer

--- a/userinterface/cameragimbalui.h
+++ b/userinterface/cameragimbalui.h
@@ -26,6 +26,9 @@ class CameraGimbalUI : public QWidget
 {
     Q_OBJECT
 
+signals:
+    void gotGimbal();
+
 public:
     explicit CameraGimbalUI(QWidget *parent = nullptr);
     ~CameraGimbalUI();
@@ -55,14 +58,11 @@ private slots:
     void on_tripleRightButton_clicked();
     void on_tripleDownButton_clicked();
     void on_trippleLeftButton_clicked();
-
     void on_yawFollowButton_clicked();
-
     void on_yawLockButton_clicked();
-
     void on_streamConnectButton_clicked();
-
     void on_streamDisconnectButton_clicked();
+    void onGimbalReceived();
 
 private:
     class SetRoiByClickOnMapModule : public MapModule {

--- a/userinterface/cameragimbalui.h
+++ b/userinterface/cameragimbalui.h
@@ -12,6 +12,7 @@
 #include "sensors/camera/gimbal.h"
 #include "userinterface/map/mapwidget.h"
 #include <QGamepad>
+#include <QMessageBox>
 
 // TODO: VehicleConnection is used in case camera modes can be changed via AUX PWM outputs
 //       This is quite specific to FLIR Pro Duo R and should be generalized (as soon as we have more cameras...)
@@ -29,6 +30,7 @@ public:
     explicit CameraGimbalUI(QWidget *parent = nullptr);
     ~CameraGimbalUI();
     void setGimbal(const QSharedPointer<Gimbal> gimbal);
+    QSharedPointer<QMessageBox> askUseGamepadMessageBox;
     QSharedPointer<MapModule> getSetRoiByClickOnMapModule() const;
 
     void setVehicleConnection(const QSharedPointer<VehicleConnection> &vehicleConnection);


### PR DESCRIPTION
Problem: any gamepad is currently captured by CameraGimbalUI, even when no gimbal is available. This can lead to crashes and undesired behavior (e.g., gamepad should be used in other applications).
Solution: try only to connect to gamepad when gimbal was detected, ask with yes/no dialog whether to connect