### PR TITLE
MavsdkVehicleServer: extend constructor with hostaddress/ip

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -6,13 +6,14 @@
 
 #include "mavsdkvehicleserver.h"
 #include <QDebug>
-#include <future>
 #include <QMetaMethod>
+#include <QTextStream>
+#include <future>
 #include <algorithm>
 #include <chrono>
 #include "WayWise/logger/logger.h"
 
-MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState)
+MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, QHostAddress controlTowerAddress)
 {
     connect(&Logger::getInstance(), &Logger::logSent, this, &MavsdkVehicleServer::on_logSent);
 
@@ -268,9 +269,10 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
     // Start publishing status on MAVLink (TODO: rate?)
     mPublishMavlinkTimer.start(100);
 
-    mavsdk::ConnectionResult result = mMavsdk.add_any_connection("udp://127.0.0.1:14540");
+    const unsigned controlTowerPort = 14540;
+    mavsdk::ConnectionResult result = mMavsdk.add_any_connection("udp://" + controlTowerAddress.toString().toStdString() + ":" + std::to_string(controlTowerPort));
     if (result == mavsdk::ConnectionResult::Success)
-        qDebug() << "MavsdkVehicleServer is listening...";
+        qDebug() << "MavsdkVehicleServer is listening on" << controlTowerAddress.toString() << "with port" << controlTowerPort;
 }
 
 void MavsdkVehicleServer::heartbeatTimeout() {

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -29,7 +29,8 @@ class MavsdkVehicleServer : public QObject
 {
     Q_OBJECT
 public:
-    explicit MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, QHostAddress controlTowerAddress = QHostAddress("127.0.0.1"));
+    explicit MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress = QHostAddress("127.0.0.1"),
+                                 const unsigned controlTowerPort = 14540, const QAbstractSocket::SocketType controlTowerSocketType = QAbstractSocket::UdpSocket); // NOTE: currently, only UDP supported in mavsdk on vehicle side
     void setUbloxRover(QSharedPointer<UbloxRover> ubloxRover);
     void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower);
     void setMovementController(QSharedPointer<MovementController> movementController);

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -11,6 +11,7 @@
 #include <QSharedPointer>
 #include <QTimer>
 #include <QDateTime>
+#include <QHostAddress>
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/action_server/action_server.h>
 #include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
@@ -28,7 +29,7 @@ class MavsdkVehicleServer : public QObject
 {
     Q_OBJECT
 public:
-    explicit MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState);
+    explicit MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, QHostAddress controlTowerAddress = QHostAddress("127.0.0.1"));
     void setUbloxRover(QSharedPointer<UbloxRover> ubloxRover);
     void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower);
     void setMovementController(QSharedPointer<MovementController> movementController);


### PR DESCRIPTION
Quickfix/feature to allow setting the ip a vehicle should talk to from main when instantiating MabsdkVehicleServer, e.g.:
`MavsdkVehicleServer mavsdkVehicleServer(mCarState, QHostAddress("192.168.111.111"));`

We need better connection management, but this pushes the problem out of WayWise (and into RCCar etc.) for the time being...