### PR TITLE
Allow DriveUI to poll ENU ref from vehicle

### DIFF
--- a/communication/vehicleconnections/mavsdkvehicleconnection.cpp
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.cpp
@@ -120,12 +120,8 @@ MavsdkVehicleConnection::MavsdkVehicleConnection(std::shared_ptr<mavsdk::System>
     });
 
     // poll update of GpsGlobalOrigin once
-    mTelemetry->get_gps_global_origin_async([this](mavsdk::Telemetry::Result result, mavsdk::Telemetry::GpsGlobalOrigin gpsGlobalOrigin){
-        if (result == mavsdk::Telemetry::Result::Success){
-            mGpsGlobalOrigin = {gpsGlobalOrigin.latitude_deg, gpsGlobalOrigin.longitude_deg, gpsGlobalOrigin.altitude_m};
-            emit gotVehicleGpsOriginLlh(mGpsGlobalOrigin);
-        }
-    });
+    MavsdkVehicleConnection::pollCurrentENUreference();
+
 
     mMavlinkPassthrough->subscribe_message(MAVLINK_MSG_ID_HEARTBEAT, [this](const mavlink_message_t &message) {
         Q_UNUSED(message)
@@ -779,6 +775,16 @@ VehicleConnection::AllParameters MavsdkVehicleConnection::getAllParametersFromVe
     }
 
     return allParameters;
+}
+
+void MavsdkVehicleConnection::pollCurrentENUreference()
+{
+    mTelemetry->get_gps_global_origin_async([this](mavsdk::Telemetry::Result result, mavsdk::Telemetry::GpsGlobalOrigin gpsGlobalOrigin){
+        if (result == mavsdk::Telemetry::Result::Success){
+            mGpsGlobalOrigin = {gpsGlobalOrigin.latitude_deg, gpsGlobalOrigin.longitude_deg, gpsGlobalOrigin.altitude_m};
+            emit gotVehicleENUreferenceLlh(mGpsGlobalOrigin);
+        }
+    });
 }
 
 VehicleConnection::Result MavsdkVehicleConnection::convertParamResult(mavsdk::Param::Result result) const

--- a/communication/vehicleconnections/mavsdkvehicleconnection.h
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.h
@@ -62,13 +62,14 @@ public:
     virtual std::pair<VehicleConnection::Result, float> getFloatParameterFromVehicle(std::string name) const override;
     virtual std::pair<VehicleConnection::Result, std::string> getCustomParameterFromVehicle(std::string name) const override;
     virtual VehicleConnection::AllParameters getAllParametersFromVehicle() override;
+    virtual void pollCurrentENUreference() override;
 
     void setConvertLocalPositionsToGlobalBeforeSending(bool convertLocalPositionsToGlobalBeforeSending);
 
     MAV_TYPE getVehicleType() const;
 
 signals:
-    void gotVehicleGpsOriginLlh(const llh_t &gpsOriginLlh);
+    void gotVehicleENUreferenceLlh(const llh_t &enuReferenceLlh);
     void gotVehicleHomeLlh(const llh_t &homePositionLlh);
     void stopWaypointFollowerSignal(); // Used internally from MAVSDK callbacks (that live in other threads)
     void gotHeartbeat(const quint8 systemId);

--- a/communication/vehicleconnections/vehicleconnection.h
+++ b/communication/vehicleconnections/vehicleconnection.h
@@ -81,6 +81,7 @@ public:
     virtual std::pair<Result, float> getFloatParameterFromVehicle(std::string name) const = 0;
     virtual std::pair<Result, std::string> getCustomParameterFromVehicle(std::string name) const = 0;
     virtual AllParameters getAllParametersFromVehicle() = 0;
+    virtual void pollCurrentENUreference() = 0;
 
     void setWaypointFollowerConnectionLocal(const QSharedPointer<WaypointFollower> &waypointFollower);
     bool hasWaypointFollowerConnectionLocal();

--- a/userinterface/driveui.cpp
+++ b/userinterface/driveui.cpp
@@ -198,3 +198,10 @@ void DriveUI::on_requestShutdownButton_clicked()
         mCurrentVehicleConnection->requestRebootOrShutdownOfSystemComponents(VehicleConnection::SystemComponent::OnboardComputer,VehicleConnection::ComponentAction::Shutdown);
 }
 
+
+void DriveUI::on_pollENUrefButton_clicked()
+{
+    if (mCurrentVehicleConnection)
+        mCurrentVehicleConnection->pollCurrentENUreference();
+}
+

--- a/userinterface/driveui.h
+++ b/userinterface/driveui.h
@@ -46,6 +46,8 @@ private slots:
 
     void on_requestShutdownButton_clicked();
 
+    void on_pollENUrefButton_clicked();
+
 private:
     Ui::DriveUI *ui;
 

--- a/userinterface/driveui.ui
+++ b/userinterface/driveui.ui
@@ -75,6 +75,22 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Advanced</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QPushButton" name="pollENUrefButton">
+        <property name="text">
+         <string>Poll ENU ref. from Vehicle</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Quite small change to add a button in ControlTower to poll the vehicle's current ENU reference:
![image](https://github.com/RISE-Dependable-Transport-Systems/WayWise/assets/2404625/83437b89-eb4b-4f04-9578-114284ebdd89)

You may wonder why the vehicle does not send it's current ENU reference periodically or on change, but that would create problems in two cases that need to be thought through: ControlTower used as a RTK GNSS basestation, controlling PX4-based drones (where GpsOrigin / ENU reference cannot be set during flight).

Adds respective interface to VehicleConnection, implemented in MavsdkVehicleConnection.