### PR TITLE
Set max speed parameter from ControlTower ui

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <chrono>
 #include "WayWise/logger/logger.h"
+#include "WayWise/communication/parameterserver.h"
 
 MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType)
 {
@@ -393,6 +394,8 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
 
     if (result == mavsdk::ConnectionResult::Success)
         qDebug() << "MavsdkVehicleServer is listening on" << controlTowerAddress.toString() << "with port" << controlTowerPort;
+
+    ParameterServer::getInstance()->provideParameter("MaxSpeed_ms", std::bind(&MavsdkVehicleServer::setManualControlMaxSpeed, this, std::placeholders::_1), std::bind(&MavsdkVehicleServer::getManualControlMaxSpeed, this));
 }
 
 void MavsdkVehicleServer::heartbeatTimeout() {
@@ -504,6 +507,11 @@ void MavsdkVehicleServer::handleManualControlMessage(mavlink_manual_control_t ma
 void MavsdkVehicleServer::setManualControlMaxSpeed(double manualControlMaxSpeed_ms)
 {
     mManualControlMaxSpeed = manualControlMaxSpeed_ms;
+}
+
+double MavsdkVehicleServer::getManualControlMaxSpeed() const
+{
+    return mManualControlMaxSpeed;
 }
 
 void MavsdkVehicleServer::mavResult(const uint16_t command, MAV_RESULT result)

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -36,6 +36,7 @@ public:
     void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower);
     void setMovementController(QSharedPointer<MovementController> movementController);
     void setManualControlMaxSpeed(double manualControlMaxSpeed_ms);
+    double getManualControlMaxSpeed() const;
     void mavResult(const uint16_t command, MAV_RESULT result);
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh);
     void on_logSent(const QString& message, const quint8& severity);

--- a/userinterface/driveui.ui
+++ b/userinterface/driveui.ui
@@ -158,13 +158,6 @@
        </layout>
       </item>
       <item>
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>TODO: set max speed via param</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QGroupBox" name="autopilotGroupBox">
         <property name="title">
          <string>Autopilot</string>


### PR DESCRIPTION
This is how to provide a parameter to parameter ui in ControlTower.

-Parameter is a double and have get/set functions
-Parameter name can be up to 15 characters long