### PR TITLE
SDVPVehiclePositionFuser: enable driving backwards (fix yaw updates)

### DIFF
--- a/sensors/fusion/sdvpvehiclepositionfuser.cpp
+++ b/sensors/fusion/sdvpvehiclepositionfuser.cpp
@@ -75,7 +75,8 @@ void SDVPVehiclePositionFuser::correctPositionAndYawGNSS(QSharedPointer<VehicleS
         PosSample closestPosFusedSample = getClosestPosFusedSampleInTime(posGNSS.getTime());
 
         // 2. Update yaw offset, limit max change depending on last driven distance reported by odometry (if available)
-        double yawErrorCmpToGNSS = posGNSS.getYaw() - closestPosFusedSample.yaw;
+        //    GNSS yaw represents direction of motion and needs to be reversed when driving backwards
+        double yawErrorCmpToGNSS = (((mPosOdomDistanceDrivenSinceGNSSupdate < 0.0) ? 180.0 : 0.0) + posGNSS.getYaw()) - closestPosFusedSample.yaw;
         while (yawErrorCmpToGNSS < -180.0) yawErrorCmpToGNSS += 360.0;
         while (yawErrorCmpToGNSS > 180.0) yawErrorCmpToGNSS -= 360.0;
         double yawMaxChangeDistanceInput = mPosOdomDistanceDrivenSinceGNSSupdate == 0.0 ? distanceMoved : abs(mPosOdomDistanceDrivenSinceGNSSupdate);


### PR DESCRIPTION
Tested using [206c8bb](https://github.com/RISE-Dependable-Transport-Systems/RCCar_minimal_example/commit/206c8bbd58ad2b122e23028b15c62515c7d3bf5d) and this change is indeed necessary, otherwise the yaw will start to drift when driving backwards.
@rickaha, I will merge directly as this was even tested on the real car already.