### PR TITLE
Split mavsdkvehicleserver into base class vehicleserver

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -13,7 +13,8 @@
 #include "WayWise/logger/logger.h"
 #include "WayWise/communication/parameterserver.h"
 
-MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType)
+MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType) :
+    VehicleServer(vehicleState)
 {
     connect(&Logger::getInstance(), &Logger::logSent, this, &MavsdkVehicleServer::on_logSent);
 

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -12,45 +12,30 @@
 #include <QTimer>
 #include <QDateTime>
 #include <QHostAddress>
+#include <communication/vehicleserver.h>
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/action_server/action_server.h>
 #include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
 #include <mavsdk/plugins/mission_raw_server/mission_raw_server.h>
 #include <mavsdk/plugins/telemetry_server/telemetry_server.h>
 #include <mavsdk/server_component.h>
-#include "autopilot/waypointfollower.h"
-#include "sensors/gnss/ubloxrover.h"
-#include "vehicles/controller/movementcontroller.h"
-#include "vehicles/vehiclestate.h"
-#include "waywise.h"
 #include "communication/mavlinkparameterserver.h"
 #include <mavsdk/plugins/mission_raw/mission_raw.h>
 
-class MavsdkVehicleServer : public QObject
+class MavsdkVehicleServer : public VehicleServer
 {
     Q_OBJECT
 public:
     explicit MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress = QHostAddress("127.0.0.1"),
                                  const unsigned controlTowerPort = 14540, const QAbstractSocket::SocketType controlTowerSocketType = QAbstractSocket::UdpSocket); // NOTE: currently, only UDP supported in mavsdk on vehicle side
-    void setUbloxRover(QSharedPointer<UbloxRover> ubloxRover);
-    void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower);
-    void setMovementController(QSharedPointer<MovementController> movementController);
-    void setManualControlMaxSpeed(double manualControlMaxSpeed_ms);
-    double getManualControlMaxSpeed() const;
+    void setUbloxRover(QSharedPointer<UbloxRover> ubloxRover) override;
+    void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower) override;
+    void setMovementController(QSharedPointer<MovementController> movementController) override;
+    void setManualControlMaxSpeed(double manualControlMaxSpeed_ms) override;
+    double getManualControlMaxSpeed() override;
+    void sendGpsOriginLlh(const llh_t &gpsOriginLlh) override;
     void mavResult(const uint16_t command, MAV_RESULT result);
-    void sendGpsOriginLlh(const llh_t &gpsOriginLlh);
     void on_logSent(const QString& message, const quint8& severity);
-
-signals:
-    void startWaypointFollower(bool fromBeginning); // to enable starting from MAVSDK thread
-    void pauseWaypointFollower();
-    void resetWaypointFollower();
-    void clearRouteOnWaypointFollower();
-    void startFollowPoint();
-    void resetHeartbeat();
-    void switchAutopilotID(const float autopilotID);
-    void rxRtcmData(const QByteArray rtcmData);
-    void shutdownOrRebootOnboardComputer(bool isShutdown);
 
 private:
     mavsdk::Mavsdk mMavsdk;
@@ -63,19 +48,13 @@ private:
     QTimer mPublishMavlinkTimer;
 
     QDateTime mMavsdkVehicleServerCreationTime = QDateTime::currentDateTime();
-    QSharedPointer<VehicleState> mVehicleState;
-    QSharedPointer<UbloxRover> mUbloxRover;
-    QSharedPointer<WaypointFollower> mWaypointFollower;
-    QSharedPointer<MovementController> mMovementController;
     ParameterServer *mParameterServer;
 
-    bool mHeartbeat;
-    QTimer mHeartbeatTimer;
     const unsigned mCountdown_ms = 2000;
 
-    void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt);
-    void heartbeatTimeout();
-    void heartbeatReset();
+    void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) override;
+    void heartbeatTimeout() override;
+    void heartbeatReset() override;
     PosPoint convertMissionItemToPosPoint(const mavsdk::MissionRawServer::MissionItem &item);
     void handleManualControlMessage(mavlink_manual_control_t manualControl);
     void sendMissionAck(quint8 type);

--- a/communication/vehicleserver.h
+++ b/communication/vehicleserver.h
@@ -1,0 +1,59 @@
+/*
+ *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+#ifndef VEHICLESERVER_H
+#define VEHICLESERVER_H
+
+#include <QObject>
+#include <QSharedPointer>
+#include <QTimer>
+#include "autopilot/waypointfollower.h"
+#include "sensors/gnss/ubloxrover.h"
+#include "vehicles/controller/movementcontroller.h"
+#include "vehicles/vehiclestate.h"
+#include "waywise.h"
+
+class VehicleServer : public QObject
+{
+    Q_OBJECT
+public:
+    VehicleServer(QSharedPointer<VehicleState> vehicleState) : mVehicleState(vehicleState) {};
+    virtual void setUbloxRover(QSharedPointer<UbloxRover> ubloxRover) = 0;
+    virtual void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower) = 0;
+    virtual void setMovementController(QSharedPointer<MovementController> movementController) = 0;
+    virtual void setManualControlMaxSpeed(double manualControlMaxSpeed_ms) = 0;
+    virtual void getManualControlMaxSpeed() = 0;
+    virtual void sendGpsOriginLlh(const llh_t &gpsOriginLlh) = 0;
+
+signals:
+    void startWaypointFollower(bool fromBeginning);
+    void pauseWaypointFollower();
+    void resetWaypointFollower();
+    void clearRouteOnWaypointFollower();
+    void startFollowPoint();
+    void resetHeartbeat();
+    void switchAutopilotID(const float autopilotID);
+    void rxRtcmData(const QByteArray rtcmData);
+    void shutdownOrRebootOnboardComputer(bool isShutdown);
+
+protected:
+    QSharedPointer<VehicleState> mVehicleState;
+    QSharedPointer<UbloxRover> mUbloxRover;
+    QSharedPointer<WaypointFollower> mWaypointFollower;
+    QSharedPointer<MovementController> mMovementController;
+
+    bool mHeartbeat;
+    QTimer mHeartbeatTimer;
+    const unsigned mCountdown_ms = 2000;
+
+    virtual void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) = 0;
+    virtual void heartbeatTimeout() = 0;
+    virtual void heartbeatReset() = 0;
+
+    double mManualControlMaxSpeed = 2.0; // [m/s]
+};
+
+#endif // VEHICLESERVER_H


### PR DESCRIPTION
This PR splits the mavsdk vehicle server into two. The purpose is to enable a shared base that can be used to build a "ISO22133" compatible vehicle server on top off (https://github.com/RI-SE/isoObject). 