### PR TITLE
Fix/mavsdk 2.0

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -20,10 +20,7 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
 
     mVehicleState = vehicleState;
 
-    mavsdk::Mavsdk::Configuration configuration(mavsdk::Mavsdk::Configuration::UsageType::Autopilot);
-    mMavsdk.set_configuration(configuration);
-
-    std::shared_ptr<mavsdk::ServerComponent> serverComponent = mMavsdk.server_component_by_type(mavsdk::Mavsdk::ServerComponentType::Autopilot);
+    std::shared_ptr<mavsdk::ServerComponent> serverComponent = mMavsdk.server_component();
 
     // Create server plugins
     MavlinkParameterServer::initialize(serverComponent);

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -38,7 +38,7 @@ public:
     void on_logSent(const QString& message, const quint8& severity);
 
 private:
-    mavsdk::Mavsdk mMavsdk;
+    mavsdk::Mavsdk mMavsdk{mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Autopilot}};
     std::shared_ptr<mavsdk::TelemetryServer> mTelemetryServer;
     mavsdk::TelemetryServer::RawGps mRawGps;
     mavsdk::TelemetryServer::GpsInfo mGpsInfo {0, mavsdk::TelemetryServer::FixType::NoGps};

--- a/communication/vehicleconnections/mavsdkstation.h
+++ b/communication/vehicleconnections/mavsdkstation.h
@@ -42,7 +42,7 @@ signals:
     void disconnectOfVehicleConnection(int vehicleID);
 
 private:
-    mavsdk::Mavsdk mMavsdk;
+    mavsdk::Mavsdk mMavsdk{mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::GroundStation}};
     QMap<int, QSharedPointer<MavsdkVehicleConnection>> mVehicleConnectionMap;
 
     QTimer mHeartbeatTimer;

--- a/tools/build_MAVSDK/README.md
+++ b/tools/build_MAVSDK/README.md
@@ -1,4 +1,7 @@
 # Simplified scripts to create *.deb files for MAVSDK
+
+**NOTE:** It is not necessary to build MAVSDK yourself anymore to build WayWise since [MAVSDK 2.0 was released](https://github.com/mavlink/MAVSDK/releases). You can just install the provided packages.
+
 All scripts are based on info from [MAVSDK](https://github.com/mavlink/MAVSDK/blob/main/.github/workflows/main.yml).
 create_amd64-deb.sh runs on your local machine, which means that the build dependencies for MAVSDK need to be installed including [fpm](https://fpm.readthedocs.io/en/stable/installation.html) (see [lines 13 to 44 here](https://github.com/mavlink/MAVSDK/blob/main/docker/Dockerfile-Ubuntu-22.04#L13)).
 All other scripts (dock*) require only [docker to be installed](https://docs.docker.com/engine/install/ubuntu/).


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes building with MAVSDK 2.0 which was recently released: https://github.com/mavlink/MAVSDK/releases


* **What is the current behavior?** (You can also link to an open issue here)
Not able to build MavsdkVehicleServer or MavsdkStation because of a deleted default constructor for the Mavsdk object.


* **What is the new behavior (if this is a feature change)?**
No new behavior.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Instead of building MAVSDK ourselves, we can now use the released packages at: https://github.com/mavlink/MAVSDK/releases 🥳
(FYI, @ariamirzai, @r2avula)

