### PR TITLE
Update workflows to MAVSDK 2.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       run: sudo apt update && sudo apt install -y git build-essential cmake libqt5serialport5-dev libgpiod-dev
 
     - name: Install MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
 
     - name: RCCar - Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       run: sudo apt update && sudo apt install -y git build-essential cmake qtcreator qtbase5-dev libqt5serialport5-dev qtmultimedia5-dev libqt5gamepad5-dev
 
     - name: Install MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
 
     - name: ControlTower - Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       run: sudo apt update && sudo apt install -y git build-essential cmake libqt5serialport5-dev libgpiod-dev
 
     - name: Install MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.0.1/libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb
 
     - name: RCCar - Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       run: sudo apt update && sudo apt install -y git build-essential cmake qtcreator qtbase5-dev libqt5serialport5-dev qtmultimedia5-dev libqt5gamepad5-dev
 
     - name: Install MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.0.1/libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-dev_2.0.1_ubuntu22.04_amd64.deb
 
     - name: ControlTower - Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update workflows to build RCCar and ControlTower with latest MAVSDK 2.2.0.


* **What is the current behavior?** (You can also link to an open issue here)
MAVSDK 2.0.1 is used.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.




