### PR TITLE
Use MAVSDK queue_message instead of send_message (fix #79)

### DIFF
--- a/userinterface/planui.cpp
+++ b/userinterface/planui.cpp
@@ -209,7 +209,7 @@ void PlanUI::on_importRouteButton_clicked()
         if (stream.name() == "routes")
             while(stream.readNextStartElement())
             {
-                llh_t importedEnuRef;
+                llh_t importedEnuRef = {0.0, 0.0, 0.0};
                 if(stream.name() == "enuref")
                 {
                     while(stream.readNextStartElement())

--- a/userinterface/planui.cpp
+++ b/userinterface/planui.cpp
@@ -206,10 +206,10 @@ void PlanUI::on_importRouteButton_clicked()
 
     if (stream.readNextStartElement())
     {
-        if (stream.name() == "routes")
+        if (stream.name() == "routes") {
+            llh_t importedEnuRef{0.0, 0.0, 0.0};
             while(stream.readNextStartElement())
             {
-                llh_t importedEnuRef = {0.0, 0.0, 0.0};
                 if(stream.name() == "enuref")
                 {
                     while(stream.readNextStartElement())
@@ -264,6 +264,7 @@ void PlanUI::on_importRouteButton_clicked()
                     }
                 }
             }
+        }
     }
 
     ui->currentRouteSpinBox->setValue(mRoutePlanner->getCurrentRouteIndex() + 1);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes all warnings we currently get when building RCCar and ControlTower coming from using the deprecated send_message interface of MAVSDK. Fixes #79 .


* **What is the new behavior (if this is a feature change)?**
No changed functionality but needed to adapt some code to use queue_message instead of send_message.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Raises minimum version of MAVSDK, because queue_message needs to be present. When using MAVSDK 2+ and not earlier dev versions, you should be fine.
@ariamirzai adding you as reviewer as I mainly touched your code for getting route from vehicle and logging, could you double check whether there is no odd behavior?

