### PR TITLE
Feature/set system id on vehicle

### DIFF
--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -34,7 +34,7 @@ public:
     void setManualControlMaxSpeed(double manualControlMaxSpeed_ms) override;
     double getManualControlMaxSpeed() const override;
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh) override;
-    void mavResult(const uint16_t command, MAV_RESULT result);
+    void mavResult(const uint16_t command, MAV_RESULT result, MAV_COMPONENT compId);
     void on_logSent(const QString& message, const quint8& severity);
 
 private:

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -38,7 +38,7 @@ public:
     void on_logSent(const QString& message, const quint8& severity);
 
 private:
-    mavsdk::Mavsdk mMavsdk{mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Autopilot}};
+    std::shared_ptr<mavsdk::Mavsdk> mMavsdk;
     std::shared_ptr<mavsdk::TelemetryServer> mTelemetryServer;
     mavsdk::TelemetryServer::RawGps mRawGps;
     mavsdk::TelemetryServer::GpsInfo mGpsInfo {0, mavsdk::TelemetryServer::FixType::NoGps};
@@ -59,6 +59,7 @@ private:
     void handleManualControlMessage(mavlink_manual_control_t manualControl);
     void sendMissionAck(quint8 type);
     double mManualControlMaxSpeed = 2.0; // [m/s]
+    quint8 mSystemId = 1;
 };
 
 #endif // MAVSDKVEHICLESERVER_H


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Create new [Configuration](https://mavsdk.mavlink.io/main/en/cpp/api_reference/classmavsdk_1_1_mavsdk_1_1_configuration.html) using a component type. In this mode, the system and component ID will be automatically chosen.


* **What is the new behavior (if this is a feature change)?**
You can set the system id from main.cpp in RCCar like: QSharedPointer<CarState> mCarState(new CarState(1));
System id and component id is now added to outgoing messages.
A custom configuration has been added to show how to set additional components that will generate a heartbeat per component.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


