### PR TITLE
Add first set of WayWise usage examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,18 @@ jobs:
     steps:
     - name: Install dependencies for examples
       run: sudo apt update && sudo apt install -y git build-essential cmake qtbase5-dev libqt5serialport5-dev libboost-program-options-dev libboost-system-dev
+
+    - name: Install MAVSDK
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.9.1/libmavsdk-dev_2.9.1_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
       
     - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
 
     - name: Examples - configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -S ${{github.workspace}}/examples -B ${{github.workspace}}/examples/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Examples - build
-      # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/examples/build --config ${{env.BUILD_TYPE}}
 
   build_rccar:
@@ -37,7 +39,7 @@ jobs:
       run: sudo apt update && sudo apt install -y git build-essential cmake libqt5serialport5-dev libgpiod-dev
 
     - name: Install MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.9.1/libmavsdk-dev_2.9.1_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
 
     - name: RCCar - Checkout
       uses: actions/checkout@v4
@@ -64,7 +66,7 @@ jobs:
       run: sudo apt update && sudo apt install -y git build-essential cmake qtcreator qtbase5-dev libqt5serialport5-dev qtmultimedia5-dev libqt5gamepad5-dev
 
     - name: Install MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.2.0/libmavsdk-dev_2.2.0_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v2.9.1/libmavsdk-dev_2.9.1_ubuntu22.04_amd64.deb && sudo dpkg --install libmavsdk-*.deb
 
     - name: ControlTower - Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,24 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  build_examples:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install dependencies for examples
+      run: sudo apt update && sudo apt install -y git build-essential cmake qtbase5-dev libqt5serialport5-dev libboost-program-options-dev libboost-system-dev
+      
+    - uses: actions/checkout@v4
+
+    - name: Examples - configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -S ${{github.workspace}}/examples -B ${{github.workspace}}/examples/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Examples - build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/examples/build --config ${{env.BUILD_TYPE}}
+
   build_rccar:
     runs-on: ubuntu-22.04
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples/RCCar_ISO22133_autopilot/isoObject"]
+	path = examples/RCCar_ISO22133_autopilot/isoObject
+	url = https://github.com/RI-SE/isoObject.git

--- a/autopilot/multiwaypointfollower.cpp
+++ b/autopilot/multiwaypointfollower.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "multiwaypointfollower.h"
-#include "WayWise/communication/parameterserver.h"
+#include "communication/parameterserver.h"
 
 MultiWaypointFollower::MultiWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower)
 {

--- a/autopilot/multiwaypointfollower.cpp
+++ b/autopilot/multiwaypointfollower.cpp
@@ -115,10 +115,12 @@ int MultiWaypointFollower::addWaypointFollower(QSharedPointer<WaypointFollower> 
     mWaypointFollowerList.append(waypointFollower);
 
     // Provide system parameters to ControlTower
-    ParameterServer::getInstance()->provideParameter("PPRadius", std::bind(&MultiWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1),
-                                                     std::bind(&MultiWaypointFollower::getPurePursuitRadius, this));
-    ParameterServer::getInstance()->provideParameter("APPRC", std::bind(&MultiWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1),
-                                                     std::bind(&MultiWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+    if (ParameterServer::getInstance()) {
+        ParameterServer::getInstance()->provideParameter("PPRadius", std::bind(&MultiWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1),
+                                                         std::bind(&MultiWaypointFollower::getPurePursuitRadius, this));
+        ParameterServer::getInstance()->provideParameter("APPRC", std::bind(&MultiWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1),
+                                                         std::bind(&MultiWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+    }
 
     return (getNumberOfWaypointFollowers() - 1) ;
 }

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QLineF>
 #include "purepursuitwaypointfollower.h"
-#include "WayWise/communication/parameterserver.h"
+#include "communication/parameterserver.h"
 
 PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<MovementController> movementController)
 {

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -15,8 +15,10 @@ PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<Movement
     connect(&mUpdateStateTimer, &QTimer::timeout, this, &PurepursuitWaypointFollower::updateState);
 
     // Provide system parameters to ControlTower
-    ParameterServer::getInstance()->provideParameter("PPRadius", std::bind(&PurepursuitWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getPurePursuitRadius, this));
-    ParameterServer::getInstance()->provideParameter("APPRC", std::bind(&PurepursuitWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+    if (ParameterServer::getInstance()) {
+        ParameterServer::getInstance()->provideParameter("PPRadius", std::bind(&PurepursuitWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getPurePursuitRadius, this));
+        ParameterServer::getInstance()->provideParameter("APPRC", std::bind(&PurepursuitWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+    }
 
 
     // Follow point requires continuous updates of the point to follow

--- a/communication/iso22133vehicleserver.h
+++ b/communication/iso22133vehicleserver.h
@@ -1,5 +1,5 @@
 
-#include <WayWise/communication/vehicleserver.h>
+#include <communication/vehicleserver.h>
 #include <QObject>
 #include <QSharedPointer>
 #include <QTimer>

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -10,8 +10,8 @@
 #include <future>
 #include <algorithm>
 #include <chrono>
-#include "WayWise/logger/logger.h"
-#include "WayWise/communication/parameterserver.h"
+#include "logger/logger.h"
+#include "communication/parameterserver.h"
 
 MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType) :
     VehicleServer(vehicleState)

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -23,7 +23,7 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
 
     mavsdk::Mavsdk::Configuration config = mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Autopilot};
     config.set_always_send_heartbeats(true);
-    config.set_system_id(mVehicleState->getId());
+    config.set_system_id(mSystemId);
     mMavsdk.reset(new mavsdk::Mavsdk{config});
 
 //    mavsdk::Mavsdk::Configuration customConfig = mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Custom};

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+project(WayWise_examples)
+
+add_subdirectory(RCCar_ISO22133_autopilot)
+add_subdirectory(RCCar_MAVLINK_autopilot)
+add_subdirectory(map_local_twocars)
+

--- a/examples/RCCar_ISO22133_autopilot/CMakeLists.txt
+++ b/examples/RCCar_ISO22133_autopilot/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(RCCar_ISO22133_autopilot LANGUAGES CXX C)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(Qt5 COMPONENTS Core Network SerialPort REQUIRED)
+find_package(MAVSDK REQUIRED)
+
+set(WAYWISE_PATH ../..)
+set(ISOOBJECT_LIBRARY ISO_object)
+add_subdirectory(isoObject)
+
+add_executable(RCCar_ISO22133_autopilot
+    main.cpp
+    ${WAYWISE_PATH}/core/simplewatchdog.cpp
+    ${WAYWISE_PATH}/vehicles/objectstate.cpp
+    ${WAYWISE_PATH}/vehicles/carstate.cpp
+    ${WAYWISE_PATH}/core/vbytearray.cpp
+    ${WAYWISE_PATH}/vehicles/controller/motorcontroller.h
+    ${WAYWISE_PATH}/vehicles/controller/movementcontroller.cpp
+    ${WAYWISE_PATH}/vehicles/controller/servocontroller.cpp
+    ${WAYWISE_PATH}/vehicles/vehiclestate.cpp
+    ${WAYWISE_PATH}/core/pospoint.cpp
+    ${WAYWISE_PATH}/vehicles/controller/carmovementcontroller.cpp
+    ${WAYWISE_PATH}/sensors/gnss/ublox.cpp
+    ${WAYWISE_PATH}/sensors/gnss/rtcm3_simple.cpp
+    ${WAYWISE_PATH}/sensors/gnss/ubloxrover.cpp
+    ${WAYWISE_PATH}/sensors/camera/gimbal.h
+    ${WAYWISE_PATH}/communication/vehicleconnections/vehicleconnection.cpp
+    ${WAYWISE_PATH}/communication/parameterserver.cpp
+    ${WAYWISE_PATH}/autopilot/waypointfollower.h
+    ${WAYWISE_PATH}/autopilot/purepursuitwaypointfollower.cpp
+    ${WAYWISE_PATH}/communication/vehicleserver.h
+    ${WAYWISE_PATH}/communication/iso22133vehicleserver.cpp
+    ${WAYWISE_PATH}/logger/logger.cpp
+)
+
+target_include_directories(RCCar_ISO22133_autopilot PRIVATE ${WAYWISE_PATH})
+
+target_link_libraries(RCCar_ISO22133_autopilot
+    PRIVATE Qt5::Network
+    PRIVATE Qt5::SerialPort
+    PUBLIC ${ISOOBJECT_LIBRARY}
+)

--- a/examples/RCCar_ISO22133_autopilot/README.md
+++ b/examples/RCCar_ISO22133_autopilot/README.md
@@ -1,0 +1,14 @@
+# RCCar_ISO22133_autopilot
+A minimal example of an ackermann-style vehicle (rccar) communicating via [ISO/TS 22133](https://www.iso.org/standard/78970.html) and featuring an autopilot.
+Use [ATOS](https://github.com/RI-SE/ATOS) to connect.
+
+A fully-featured implementation for a physical rccar (communicating via MAVLINK) can be found at [RCCar](https://github.com/RISE-Dependable-Transport-Systems/RCCar)
+
+## Installing Prerequisites (tested on Ubuntu 20.04/22.04) & Building
+    # Clone submodules
+    git submodule update --init --recursive isoObject
+
+    sudo apt install git build-essential cmake libqt5serialport5-dev libboost-program-options-dev libboost-system-dev
+    mkdir build && cd build
+    cmake ..
+    make -j4

--- a/examples/RCCar_ISO22133_autopilot/main.cpp
+++ b/examples/RCCar_ISO22133_autopilot/main.cpp
@@ -1,0 +1,54 @@
+#include <QCoreApplication>
+#include "core/simplewatchdog.h"
+#include "vehicles/carstate.h"
+#include "vehicles/controller/carmovementcontroller.h"
+#include "autopilot/purepursuitwaypointfollower.h"
+#include "communication/parameterserver.h"
+#include "communication/iso22133vehicleserver.h"
+#include "logger/logger.h"
+
+int main(int argc, char *argv[])
+{
+    Logger::initVehicle();
+
+    QCoreApplication a(argc, argv);
+    const int mUpdateVehicleStatePeriod_ms = 25;
+    QTimer mUpdateVehicleStateTimer;
+
+    QSharedPointer<CarState> mCarState(new CarState);
+    iso22133VehicleServer iso22133VehicleServer(mCarState, "127.0.0.1");
+
+    // --- Lower-level control setup ---
+    QSharedPointer<CarMovementController> mCarMovementController(new CarMovementController(mCarState));
+
+    QObject::connect(&mUpdateVehicleStateTimer, &QTimer::timeout, [&](){
+        mCarState->simulationStep(mUpdateVehicleStatePeriod_ms, PosType::fused);
+    });
+    mUpdateVehicleStateTimer.start(mUpdateVehicleStatePeriod_ms);
+
+    // --- Autopilot ---
+    QSharedPointer<PurepursuitWaypointFollower> mWaypointFollower(new PurepursuitWaypointFollower(mCarMovementController));
+    mWaypointFollower->setPurePursuitRadius(1.0);
+    mWaypointFollower->setRepeatRoute(false);
+
+    // Setup ISO22133 communication towards ATOS
+    iso22133VehicleServer.setMovementController(mCarMovementController);
+    iso22133VehicleServer.setWaypointFollower(mWaypointFollower);
+
+    // Watchdog that warns when EventLoop is slowed down
+    SimpleWatchdog watchdog;
+
+    qDebug() << "\n" // by hjw
+             << "                    .------.\n"
+             << "                    :|||\"\"\"`.`.\n"
+             << "                    :|||     7.`.\n"
+             << " .===+===+===+===+===||`----L7'-`7`---.._\n"
+             << " []ISO22133 autopilot|| ==       |       \"\"\"-.\n"
+             << " []...._____.example.||........../ _____ ____|\n"
+             << "c\\____/,---.\\_       ||_________/ /,---.\\_  _/\n"
+             << "  /_,-/ ,-. \\ `._____|__________||/ ,-. \\ \\_[\n"
+             << "     /\\ `-' /                    /\\ `-' /\n"
+             << "       `---'                       `---'\n";
+
+    return a.exec();
+}

--- a/examples/RCCar_MAVLINK_autopilot/CMakeLists.txt
+++ b/examples/RCCar_MAVLINK_autopilot/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(RCCar_MAVLINK_autopilot LANGUAGES CXX C)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(Qt5 COMPONENTS Core Network SerialPort REQUIRED)
+find_package(MAVSDK REQUIRED)
+
+set(WAYWISE_PATH ../..)
+
+add_executable(RCCar_MAVLINK_autopilot
+    main.cpp
+    ${WAYWISE_PATH}/core/simplewatchdog.cpp
+    ${WAYWISE_PATH}/vehicles/objectstate.cpp
+    ${WAYWISE_PATH}/vehicles/carstate.cpp
+    ${WAYWISE_PATH}/core/vbytearray.cpp
+    ${WAYWISE_PATH}/vehicles/controller/motorcontroller.h
+    ${WAYWISE_PATH}/vehicles/controller/movementcontroller.cpp
+    ${WAYWISE_PATH}/vehicles/controller/servocontroller.cpp
+    ${WAYWISE_PATH}/vehicles/vehiclestate.cpp
+    ${WAYWISE_PATH}/core/pospoint.cpp
+    ${WAYWISE_PATH}/vehicles/controller/carmovementcontroller.cpp
+    ${WAYWISE_PATH}/sensors/gnss/ublox.cpp
+    ${WAYWISE_PATH}/sensors/gnss/rtcm3_simple.cpp
+    ${WAYWISE_PATH}/sensors/gnss/ubloxrover.cpp
+    ${WAYWISE_PATH}/sensors/camera/gimbal.h
+    ${WAYWISE_PATH}/communication/vehicleconnections/vehicleconnection.cpp
+    ${WAYWISE_PATH}/communication/mavlinkparameterserver.cpp
+    ${WAYWISE_PATH}/communication/parameterserver.cpp
+    ${WAYWISE_PATH}/autopilot/waypointfollower.h
+    ${WAYWISE_PATH}/autopilot/purepursuitwaypointfollower.cpp
+    ${WAYWISE_PATH}/communication/vehicleserver.h
+    ${WAYWISE_PATH}/communication/mavsdkvehicleserver.cpp
+    ${WAYWISE_PATH}/logger/logger.cpp
+)
+
+target_include_directories(RCCar_MAVLINK_autopilot PRIVATE ${WAYWISE_PATH})
+
+target_link_libraries(RCCar_MAVLINK_autopilot
+    PRIVATE Qt5::Network
+    PRIVATE Qt5::SerialPort
+    PRIVATE MAVSDK::mavsdk
+)

--- a/examples/RCCar_MAVLINK_autopilot/README.md
+++ b/examples/RCCar_MAVLINK_autopilot/README.md
@@ -1,0 +1,10 @@
+MAVSDK 2.0 or newer is required and pre-built releases can be found at https://github.com/mavlink/MAVSDK/releases. 
+
+## Installing Prerequisites (tested on Ubuntu 20.04/22.04) & Building
+    # Installing MAVSDK
+    sudo dpkg -i libmavsdk-dev*.deb
+
+    sudo apt install git build-essential cmake libqt5serialport5-dev
+    mkdir build && cd build
+    cmake ..
+    make -j4

--- a/examples/RCCar_MAVLINK_autopilot/README.md
+++ b/examples/RCCar_MAVLINK_autopilot/README.md
@@ -1,6 +1,12 @@
-MAVSDK 2.0 or newer is required and pre-built releases can be found at https://github.com/mavlink/MAVSDK/releases. 
+# RCCar_MAVLINK_autopilot
+A minimal example of an ackermann-style vehicle (rccar) communicating via MAVLINK and featuring an autopilot.
+Use [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower) to connect.
+
+A fully-featured implementation for a physical rccar can be found at [RCCar](https://github.com/RISE-Dependable-Transport-Systems/RCCar)
 
 ## Installing Prerequisites (tested on Ubuntu 20.04/22.04) & Building
+MAVSDK 2.0 or newer is required and pre-built releases can be found at https://github.com/mavlink/MAVSDK/releases. 
+
     # Installing MAVSDK
     sudo dpkg -i libmavsdk-dev*.deb
 

--- a/examples/RCCar_MAVLINK_autopilot/main.cpp
+++ b/examples/RCCar_MAVLINK_autopilot/main.cpp
@@ -1,0 +1,53 @@
+#include <QCoreApplication>
+#include "../../core/simplewatchdog.h"
+#include "../../vehicles/carstate.h"
+#include "../../vehicles/controller/carmovementcontroller.h"
+#include "../../autopilot/purepursuitwaypointfollower.h"
+#include "../../communication/mavsdkvehicleserver.h"
+#include "../../logger/logger.h"
+
+int main(int argc, char *argv[])
+{
+    Logger::initVehicle();
+
+    QCoreApplication a(argc, argv);
+    const int mUpdateVehicleStatePeriod_ms = 25;
+    QTimer mUpdateVehicleStateTimer;
+
+    QSharedPointer<CarState> mCarState(new CarState);
+    MavsdkVehicleServer mavsdkVehicleServer(mCarState);
+
+    // --- Lower-level control setup ---
+    QSharedPointer<CarMovementController> mCarMovementController(new CarMovementController(mCarState));
+
+    QObject::connect(&mUpdateVehicleStateTimer, &QTimer::timeout, [&](){
+        mCarState->simulationStep(mUpdateVehicleStatePeriod_ms, PosType::fused);
+    });
+    mUpdateVehicleStateTimer.start(mUpdateVehicleStatePeriod_ms);
+
+    // --- Autopilot ---
+    QSharedPointer<PurepursuitWaypointFollower> mWaypointFollower(new PurepursuitWaypointFollower(mCarMovementController));
+    mWaypointFollower->setPurePursuitRadius(1.0);
+    mWaypointFollower->setRepeatRoute(false);
+
+    // Setup MAVLINK communication towards ControlTower
+    mavsdkVehicleServer.setMovementController(mCarMovementController);
+    mavsdkVehicleServer.setWaypointFollower(mWaypointFollower);
+
+    // Watchdog that warns when EventLoop is slowed down
+    SimpleWatchdog watchdog;
+
+    qDebug() << "\n" // by hjw
+             << "                    .------.\n"
+             << "                    :|||\"\"\"`.`.\n"
+             << "                    :|||     7.`.\n"
+             << " .===+===+===+===+===||`----L7'-`7`---.._\n"
+             << " [] MAVLINK autopilot|| ==       |       \"\"\"-.\n"
+             << " []...._____.example.||........../ _____ ____|\n"
+             << "c\\____/,---.\\_       ||_________/ /,---.\\_  _/\n"
+             << "  /_,-/ ,-. \\ `._____|__________||/ ,-. \\ \\_[\n"
+             << "     /\\ `-' /                    /\\ `-' /\n"
+             << "       `---'                       `---'\n";
+
+    return a.exec();
+}

--- a/examples/RCCar_MAVLINK_autopilot/main.cpp
+++ b/examples/RCCar_MAVLINK_autopilot/main.cpp
@@ -1,10 +1,10 @@
 #include <QCoreApplication>
-#include "../../core/simplewatchdog.h"
-#include "../../vehicles/carstate.h"
-#include "../../vehicles/controller/carmovementcontroller.h"
-#include "../../autopilot/purepursuitwaypointfollower.h"
-#include "../../communication/mavsdkvehicleserver.h"
-#include "../../logger/logger.h"
+#include "core/simplewatchdog.h"
+#include "vehicles/carstate.h"
+#include "vehicles/controller/carmovementcontroller.h"
+#include "autopilot/purepursuitwaypointfollower.h"
+#include "communication/mavsdkvehicleserver.h"
+#include "logger/logger.h"
 
 int main(int argc, char *argv[])
 {

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples on how to use WayWise
+See README.md in each respective folder and build examples there.
+
+Assuming you have all requirements installed and cloned submodules recursively, you can build all examples at once:
+
+    # In WayWise/examples:
+    mkdir build && cd build
+    cmake ..
+    make -j4

--- a/examples/map_local_twocars/CMakeLists.txt
+++ b/examples/map_local_twocars/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(map_local_twocars LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(Qt5 COMPONENTS Widgets Core Network PrintSupport REQUIRED)
+
+set(WAYWISE_PATH ../..)
+
+add_executable(map_local_twocars
+    main.cpp
+    mainwindow.cpp
+    mainwindow.h
+    mainwindow.ui
+    ${WAYWISE_PATH}/vehicles/objectstate.cpp
+    ${WAYWISE_PATH}/vehicles/vehiclestate.cpp
+    ${WAYWISE_PATH}/vehicles/carstate.cpp
+    ${WAYWISE_PATH}/autopilot/waypointfollower.h
+    ${WAYWISE_PATH}/vehicles/controller/movementcontroller.cpp
+    ${WAYWISE_PATH}/sensors/camera/gimbal.h
+    ${WAYWISE_PATH}/communication/vehicleconnections/vehicleconnection.cpp
+    ${WAYWISE_PATH}/communication/parameterserver.cpp
+    ${WAYWISE_PATH}/autopilot/purepursuitwaypointfollower.cpp
+    ${WAYWISE_PATH}/core/coordinatetransforms.h
+    ${WAYWISE_PATH}/userinterface/map/mapwidget.cpp
+    ${WAYWISE_PATH}/userinterface/map/osmclient.cpp
+    ${WAYWISE_PATH}/userinterface/map/osmtile.cpp
+    ${WAYWISE_PATH}/core/pospoint.cpp
+)
+
+target_include_directories(map_local_twocars PRIVATE ${WAYWISE_PATH}/)
+
+target_link_libraries(map_local_twocars
+    PRIVATE Qt5::Widgets
+    PRIVATE Qt5::Network
+    PRIVATE Qt5::PrintSupport
+)

--- a/examples/map_local_twocars/README.md
+++ b/examples/map_local_twocars/README.md
@@ -1,0 +1,11 @@
+# map_local_twocars
+A minimal UI example showing a map and two cars driving in circles. No external communication is used.
+
+A fully-featured implementation for controlling WayWise-based vehicles (MAVLINK communication) can be found at [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower).
+
+## Installing Prerequisites (tested on Ubuntu 20.04/22.04) & Building
+
+    sudo apt install git build-essential cmake qtbase5-dev
+    mkdir build && cd build
+    cmake ..
+    make -j4

--- a/examples/map_local_twocars/main.cpp
+++ b/examples/map_local_twocars/main.cpp
@@ -1,0 +1,11 @@
+#include "mainwindow.h"
+
+#include <QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication a(argc, argv);
+    MainWindow w;
+    w.show();
+    return a.exec();
+}

--- a/examples/map_local_twocars/mainwindow.cpp
+++ b/examples/map_local_twocars/mainwindow.cpp
@@ -1,0 +1,35 @@
+#include "mainwindow.h"
+#include "./ui_mainwindow.h"
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+    , ui(new Ui::MainWindow)
+{
+    ui->setupUi(this);    
+    ui->mapWidget->setScaleFactor(0.04);
+
+    // Prepare Car 1
+    car1 = QSharedPointer<CarState>::create(1, Qt::blue);
+    ui->mapWidget->addObjectState(car1);
+    car1->setSpeed(2);
+    car1->setSteering(0.5);
+
+    // Prepare Car 2
+    car2 = QSharedPointer<CarState>::create(2, Qt::red);
+    ui->mapWidget->addObjectState(car2);
+    car2->setSpeed(2);
+    car2->setSteering(-0.5);
+
+    // Setup simulation
+    QObject::connect(&mUpdateVehicleStateTimer, &QTimer::timeout, [=](){
+        car1->simulationStep(mUpdateVehicleStatePeriod_ms);
+        car2->simulationStep(mUpdateVehicleStatePeriod_ms);
+    });
+    mUpdateVehicleStateTimer.start(mUpdateVehicleStatePeriod_ms);
+}
+
+MainWindow::~MainWindow()
+{
+    delete ui;
+}
+

--- a/examples/map_local_twocars/mainwindow.h
+++ b/examples/map_local_twocars/mainwindow.h
@@ -1,0 +1,27 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include <QTimer>
+#include "vehicles/carstate.h"
+
+QT_BEGIN_NAMESPACE
+namespace Ui { class MainWindow; }
+QT_END_NAMESPACE
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
+
+private:
+    Ui::MainWindow *ui;
+    const int mUpdateVehicleStatePeriod_ms = 25;
+    QTimer mUpdateVehicleStateTimer;
+    QSharedPointer<CarState> car1;
+    QSharedPointer<CarState> car2;
+};
+#endif // MAINWINDOW_H

--- a/examples/map_local_twocars/mainwindow.ui
+++ b/examples/map_local_twocars/mainwindow.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="MapWidget" name="mapWidget" native="true"/>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>20</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MapWidget</class>
+   <extends>QWidget</extends>
+   <header>userinterface/map/mapwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/vehicles/carstate.h
+++ b/vehicles/carstate.h
@@ -23,7 +23,7 @@ class CarState : public VehicleState
 {
     Q_OBJECT
 public:
-    CarState(int id = 0, Qt::GlobalColor color = Qt::red);
+    CarState(int id = 1, Qt::GlobalColor color = Qt::red);
 #ifdef QT_GUI_LIB
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) override;
     virtual QPainterPath getBoundingBox() const override;

--- a/vehicles/carstate.h
+++ b/vehicles/carstate.h
@@ -58,7 +58,7 @@ public:
 private:
     double mRearOverhang = 0.0; //[m]
     double mFrontOverhang = 0.0; //[m]
-    double mAxisDistance; // [m]
+    double mAxisDistance = 0.0; // [m]
     double mMaxSteeringAngle = 0.0; // [rad]
     double mMinTurnRadiusRear = std::numeric_limits<double>::infinity(); // [m]
 

--- a/vehicles/objectstate.h
+++ b/vehicles/objectstate.h
@@ -29,7 +29,7 @@ public:
     typedef int ObjectID_t;
     typedef xyz_t Velocity;
     typedef xyz_t Acceleration;
-    ObjectState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
+    ObjectState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::red);
 #ifdef QT_GUI_LIB
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
     virtual QPainterPath getBoundingBox() const { return QPainterPath(); }

--- a/vehicles/vehiclestate.h
+++ b/vehicles/vehiclestate.h
@@ -45,7 +45,7 @@ public:
         Rattitude
     };
 
-    VehicleState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
+    VehicleState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::red);
 
     // Static state
     double getLength() const { return mLength; }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Rather doc update than feature. It is part of the quest to make WayWise more accessible to others.
The examples folder adds three usage examples:
    - RCCar_MAVLINK_autopilot: was previously a separate repository "RCCar_minimal_example", moving it here makes WayWise more self-contained
    - RCCar_ISO22133_autopilot: same as previous example but using ISO 22133 based communication contributed by AstaZero instead of MAVLINK. @Robert108 could you test this one towards ATOS?
    - map_local_twocars: simple ui example showing two cars driving in circles on a map


* **What is the current behavior?** (You can also link to an open issue here)
No examples.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. Added very minor stability fixes while creating the examples but no functionality is changed.


Will add more UI examples whenever I find time... 🙂
