### PR TITLE
Null check for ubloxrover in iso22133vehicleserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tools/MAVSDK
+
+# Build folders
+build

--- a/communication/iso22133vehicleserver.cpp
+++ b/communication/iso22133vehicleserver.cpp
@@ -157,7 +157,12 @@ void iso22133VehicleServer::onOSEM(ObjectSettingsType &osem) {
     qDebug() << "Object Settings Received";
     setObjectSettings(osem);
     const llh_t llh = {osem.coordinateSystemOrigin.latitude_deg, osem.coordinateSystemOrigin.longitude_deg, osem.coordinateSystemOrigin.altitude_m};
-    mUbloxRover->setEnuRef(llh);
+    if (!mUbloxRover.isNull())
+    {
+        mUbloxRover->setEnuRef(llh);
+    } else {
+        qWarning() << "No UbloxRover set to receive llh!!";
+    }
 }
 
 void iso22133VehicleServer::onTRAJ() {

--- a/examples/RCCar_ISO22133_autopilot/main.cpp
+++ b/examples/RCCar_ISO22133_autopilot/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
     QTimer mUpdateVehicleStateTimer;
 
     QSharedPointer<CarState> mCarState(new CarState);
-    iso22133VehicleServer iso22133VehicleServer(mCarState, "127.0.0.1");
+    iso22133VehicleServer iso22133VehicleServer(mCarState, "0.0.0.0");
 
     // --- Lower-level control setup ---
     QSharedPointer<CarMovementController> mCarMovementController(new CarMovementController(mCarState));


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix that iso22133 vehicleserver seg faults if OSEM is received when no ubloxrover is set.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**
The app prints a warning instead and simulated movement can be used. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


