### PR TITLE
ObjectState (and childclasses): default ID not allowed to be zero

### DIFF
--- a/vehicles/carstate.cpp
+++ b/vehicles/carstate.cpp
@@ -11,7 +11,7 @@
 #include <QDebug>
 #include <QDateTime>
 
-CarState::CarState(int id, Qt::GlobalColor color) : VehicleState(id, color)
+CarState::CarState(ObjectID_t id, Qt::GlobalColor color) : VehicleState(id, color)
 {
 
 }

--- a/vehicles/carstate.h
+++ b/vehicles/carstate.h
@@ -23,7 +23,7 @@ class CarState : public VehicleState
 {
     Q_OBJECT
 public:
-    CarState(int id = 1, Qt::GlobalColor color = Qt::red);
+    CarState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::red);
 #ifdef QT_GUI_LIB
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) override;
     virtual QPainterPath getBoundingBox() const override;

--- a/vehicles/copterstate.cpp
+++ b/vehicles/copterstate.cpp
@@ -10,7 +10,7 @@
 #include <QPalette>
 #include <QTextStream>
 
-CopterState::CopterState(int id, Qt::GlobalColor color) : VehicleState(id, color)
+CopterState::CopterState(ObjectID_t id, Qt::GlobalColor color) : VehicleState(id, color)
 {
     // Default values for Holybro S500/X500
     mFrameType = CopterFrameType::X;

--- a/vehicles/copterstate.h
+++ b/vehicles/copterstate.h
@@ -32,7 +32,7 @@ public:
         Landing
     };
 
-    CopterState(int id = 0, Qt::GlobalColor color = Qt::red);
+    CopterState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::red);
 
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true);
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType) override;

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -7,7 +7,7 @@
 #include "trailerstate.h"
 #include <QDebug>
 
-TrailerState::TrailerState(ObjectState::ObjectID_t id, Qt::GlobalColor color) : ObjectState (id, color)
+TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : ObjectState (id, color)
 {    
 
     mLength = 0.96; // griffin specific

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -21,7 +21,7 @@ class TrailerState : public ObjectState
     Q_OBJECT
 public:
 
-    TrailerState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::white);
+    TrailerState(ObjectID_t id = 25, Qt::GlobalColor color = Qt::white);
 
     double getLength() const { return mLength; }
     void setLength(double length) { mLength = length; }

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -9,7 +9,7 @@
 #include <QDebug>
 #include <QDateTime>
 
-TruckState::TruckState(int id, Qt::GlobalColor color) : CarState(id, color)
+TruckState::TruckState(ObjectID_t id, Qt::GlobalColor color) : CarState(id, color)
 {
     // Additional initialization if needed for the TruckState
 }

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -15,7 +15,7 @@ class TruckState : public CarState
 {
     Q_OBJECT
 public:
-    TruckState(int id = 0, Qt::GlobalColor color = Qt::blue);
+    TruckState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::blue);
 
     // Additional set/get state for angle sensor
     uint16_t getTrailerAngleRaw() const { return mTrailerRawAngle; }

--- a/vehicles/vehiclestate.cpp
+++ b/vehicles/vehiclestate.cpp
@@ -8,7 +8,7 @@
 #include "vehiclestate.h"
 #include <QDebug>
 
-VehicleState::VehicleState(ObjectState::ObjectID_t id, Qt::GlobalColor color)
+VehicleState::VehicleState(ObjectID_t id, Qt::GlobalColor color)
     : ObjectState (id, color)
 {
     mTime = QTime();


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Some object ids are 0


* **What is the new behavior (if this is a feature change)?**
Object ids are now one or larger, and defined the same way


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


