### PR TITLE
add functionality to pure pursuit to calculate curvature with a trailer

### DIFF
--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -91,39 +91,6 @@ void PurepursuitWaypointFollower::resetState()
     mCurrentState.currentWaypointIndex = mWaypointList.size();
 }
 
-double PurepursuitWaypointFollower::getCurvatureWithTrailer(QSharedPointer<TruckState> truckState, const QPointF &point, PosType vehiclePosType)
-{
-    const PosPoint vehiclePos = truckState->getPosition(vehiclePosType);
-    double currYaw_rad = vehiclePos.getYaw() * M_PI / 180.0;
-    double measuredTrailerAngle = truckState->getTrailerAngleRadians() ;
-    double l2 = 0.715;; // trailer wheelbase in meters
-
-    if (truckState->getSpeed()> 0 ){
-        QPointF pointInVehicleFrame;
-        pointInVehicleFrame.setX(point.x()-vehiclePos.getX());
-        pointInVehicleFrame.setY(point.y()-vehiclePos.getY());
-        double theta_err =  atan2(pointInVehicleFrame.y(), pointInVehicleFrame.x()) - currYaw_rad;
-        double desired_hitch_angle = atan(2*l2*sin(theta_err)); // desired trailer/hitch angle
-        double k=1; //gain
-        return  k*( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2)) ;
-
-    } else {
-        double trailerYaw = currYaw_rad - measuredTrailerAngle ;
-        double delta_x_ = (l2) * cos( trailerYaw);
-        double delta_y = (l2) * sin( trailerYaw);
-        double trailerPositionx = vehiclePos.getX() - delta_x_;
-        double trailerPositiony = vehiclePos.getY() - delta_y;
-
-        QPointF pointInTrailerFrame;
-        pointInTrailerFrame.setX(point.x()-trailerPositionx);
-        pointInTrailerFrame.setY(point.y()-trailerPositiony);
-        double theta_err =  atan2(pointInTrailerFrame.y(), pointInTrailerFrame.x()) - trailerYaw;
-        double desired_hitch_angle = atan(2*l2*sin(theta_err) / truckState->getAutopilotRadius() );
-        double k=-2.5; // gain
-        return  k*( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2)) ;
-    }
-}
-
 void PurepursuitWaypointFollower::updateState()
 {
     QPointF currentVehiclePositionXY = mVehicleState->getPosition(mPosTypeUsed).getPoint();

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -14,6 +14,7 @@
 #include <QPointF>
 #include <QTimer>
 #include "vehicles/vehiclestate.h"
+#include "WayWise/vehicles/truckstate.h"
 #include "vehicles/controller/movementcontroller.h"
 #include "communication/vehicleconnections/vehicleconnection.h"
 #include "autopilot/waypointfollower.h"
@@ -64,6 +65,8 @@ public:
     virtual void resetState() override;
 
     virtual QList<PosPoint> getCurrentRoute() override;
+
+    double getCurvatureWithTrailer(QSharedPointer<TruckState> truckState, const QPointF &point, PosType vehiclePosType);
 
     double getInterpolatedSpeed(const PosPoint &currentGoal, const PosPoint &lastWaypoint, const PosPoint &nextWaypoint);
 

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -14,7 +14,6 @@
 #include <QPointF>
 #include <QTimer>
 #include "vehicles/vehiclestate.h"
-#include "WayWise/vehicles/truckstate.h"
 #include "vehicles/controller/movementcontroller.h"
 #include "communication/vehicleconnections/vehicleconnection.h"
 #include "autopilot/waypointfollower.h"
@@ -65,8 +64,6 @@ public:
     virtual void resetState() override;
 
     virtual QList<PosPoint> getCurrentRoute() override;
-
-    double getCurvatureWithTrailer(QSharedPointer<TruckState> truckState, const QPointF &point, PosType vehiclePosType);
 
     double getInterpolatedSpeed(const PosPoint &currentGoal, const PosPoint &lastWaypoint, const PosPoint &nextWaypoint);
 

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -8,15 +8,15 @@
 #include <QDebug>
 
 TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : ObjectState (id, color)
-{    
+{
 
     mLength = 0.96; // griffin specific
-    mWidth = 0.21;  // griffin specific 
-    
+    mWidth = 0.21;  // griffin specific
+
 }
 
 #ifdef QT_GUI_LIB
-// draw on demand 
+// draw on demand
 void TrailerState::drawTrailer(QPainter &painter, const QTransform &drawTrans, const PosPoint &carPos, double angle)
 {
 
@@ -33,7 +33,7 @@ void TrailerState::drawTrailer(QPainter &painter, const QTransform &drawTrans, c
     // Wheels
     painter.setBrush(QBrush(Qt::darkGray));
     painter.drawRoundedRect(trailer_len - trailer_len / 2.5,-(trailer_w / 2), trailer_len / 9.0, trailer_w, trailer_corner / 3, trailer_corner / 3);
-    
+
     // Draw trailer
     // simple draw a rectangle representing the trailer
     painter.setBrush(getColor());
@@ -42,8 +42,8 @@ void TrailerState::drawTrailer(QPainter &painter, const QTransform &drawTrans, c
 }
 
 void TrailerState::draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected){
-    // draw a trailer indepentently 
-     
+    // draw a trailer indepentently
+
     PosPoint pos = getPosition();
     double x = pos.getX() * 1000.0  ;// convert from m to mm (on the map objects are in mm)
     double y = pos.getY() * 1000.0  ;
@@ -58,7 +58,7 @@ void TrailerState::draw(QPainter &painter, const QTransform &drawTrans, const QT
     // Wheels
     painter.setBrush(QBrush(Qt::darkGray));
     painter.drawRoundedRect(trailer_len - trailer_len / 2.5,-(trailer_w / 2), trailer_len / 9.0, trailer_w, trailer_corner / 3, trailer_corner / 3);
-    
+
     // Draw trailer
     // simple draw a rectangle representing the trailer
     painter.setBrush(getColor());

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -1,8 +1,8 @@
 /*
  *     Copyright 2024 RISE Sweden
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
- * Specialisation of ObjectState for tailer state 
+ *
+ * Specialisation of ObjectState for tailer state
  */
 
 #ifndef TRAILERSTATE_H

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -27,6 +27,8 @@ public:
     void setLength(double length) { mLength = length; }
     double getWidth() const { return mWidth; }
     void setWidth(double width) { mWidth = width; }
+    double getWheelBase() const{ return mWheelBase;}
+    void setWheelBase(double value){ mWheelBase = value;}
 
 #ifdef QT_GUI_LIB
     // drawing functions for trailer (to draw a trailer)
@@ -38,6 +40,7 @@ public:
 private:
     double mLength; // [m]
     double mWidth; // [m]
+    double mWheelBase; //[m]
 };
 
 #endif // TRAILERSTATE_H

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -38,7 +38,7 @@ double TruckState::getCurvatureWithTrailer(const QPointF &point)
     const PosPoint vehiclePos; // = getPosition(vehiclePosType);
     double currYaw_rad = vehiclePos.getYaw() * M_PI / 180.0;
     double measuredTrailerAngle = getTrailerAngleRadians() ;
-    double l2 = 0.715;; // trailer wheelbase in meters
+    double l2 = mTrailerState->getWheelBase(); // trailer wheelbase in meters
 
     if (getSpeed()> 0 ){
         QPointF pointInVehicleFrame;
@@ -46,7 +46,7 @@ double TruckState::getCurvatureWithTrailer(const QPointF &point)
         pointInVehicleFrame.setY(point.y()-vehiclePos.getY());
         double theta_err =  atan2(pointInVehicleFrame.y(), pointInVehicleFrame.x()) - currYaw_rad;
         double desired_hitch_angle = atan(2*l2*sin(theta_err)); // desired trailer/hitch angle
-        double k=1; //gain
+        double k = getPurePursuitForwardGain(); //gain
         return  k*( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2)) ;
 
     } else {
@@ -61,7 +61,7 @@ double TruckState::getCurvatureWithTrailer(const QPointF &point)
         pointInTrailerFrame.setY(point.y()-trailerPositiony);
         double theta_err =  atan2(pointInTrailerFrame.y(), pointInTrailerFrame.x()) - trailerYaw;
         double desired_hitch_angle = atan(2*l2*sin(theta_err) / getAutopilotRadius() );
-        double k=-2.5; // gain
+        double k = getPurePursuitReverseGain(); // gain
         return  k*( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2)) ;
     }
 }

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -38,9 +38,9 @@ double TruckState::getCurvatureWithTrailer(const QPointF &pointInVehicleFrame)
     if (getSpeed()> 0 ){
         double theta_err =  atan2(pointInVehicleFrame.y(), pointInVehicleFrame.x());
         double desired_hitch_angle = atan(2*l2*sin(theta_err)); // desired trailer/hitch angle
-        double k = getPurePursuitForwardGain(); //gain
-        return  k*( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2)) ;
-
+        double gain = getPurePursuitForwardGain();
+        double curve = gain *( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2)) ;
+        return curve/cos(measuredTrailerAngle);
     } else {
         double trailerYawInVehicleFrame = -measuredTrailerAngle ;
         double trailerPositionInVehicleFrame_x = -(l2) * cos(trailerYawInVehicleFrame);
@@ -49,8 +49,9 @@ double TruckState::getCurvatureWithTrailer(const QPointF &pointInVehicleFrame)
         double theta_err =  atan2(pointInVehicleFrame.y()-trailerPositionInVehicleFrame_y,
             pointInVehicleFrame.x()-trailerPositionInVehicleFrame_x) - trailerYawInVehicleFrame;
         double desired_hitch_angle = atan(2*l2*sin(theta_err) / getAutopilotRadius() );
-        double k = getPurePursuitReverseGain(); // gain
-        return k*( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2));
+        double gain = getPurePursuitReverseGain();
+        double curve = gain *( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2));
+        return curve/cos(measuredTrailerAngle);
     }
 }
 

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -23,19 +23,15 @@ public:
     double getTrailerAngleDegrees() const { return mTrailerAngleDegress; }
     double getTrailerWheelBase() const { return mtrailerwheelbase; }
 
-    void setTrailerAngle(uint16_t raw_angle , double angle_in_radians, double agnle_in_degrees) { 
-        mTrailerRawAngle = raw_angle;
-        mTrailerAngleRadians = angle_in_radians;
-        mTrailerAngleDegress = agnle_in_degrees;
-    }
+    void setTrailerAngle(uint16_t raw_angle , double angle_in_radians, double agnle_in_degrees);
 
     // Override the updateOdomPositionAndYaw function to consider the angle of the trailer
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
 
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
 
-    QSharedPointer<TrailerState> getTrailerState() const { return mTrailerState; }
-    void setTrailerState(QSharedPointer<TrailerState> newTrailerState) { mTrailerState=newTrailerState; }
+    QSharedPointer<TrailerState> getTrailerState() const;
+    void setTrailerState(QSharedPointer<TrailerState> newTrailerState);
 
     bool getHasTrailer() const ;
     void setHasTrailer(bool mHasTrailer);

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -36,6 +36,12 @@ public:
     bool getHasTrailer() const ;
     void setHasTrailer(bool mHasTrailer);
 
+    double getPurePursuitForwardGain() const{ return mPurePursuitForwardGain;}
+    void setPurePursuitForwardGain(double value){ mPurePursuitForwardGain = value;}
+
+    double getPurePursuitReverseGain() const{ return mPurePursuitReverseGain;}
+    void setPurePursuitReverseGain(double value){ mPurePursuitReverseGain = value;}
+
 #ifdef QT_GUI_LIB
     // Override or add drawing functions if needed (to draw a truck)
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) override;
@@ -48,6 +54,9 @@ private:
     double mtrailerwheelbase; // trailer wheelbase
     QSharedPointer<TrailerState> mTrailerState; // trailer created dynamically
     bool mHasTrailer = false;
+
+    double mPurePursuitForwardGain;
+    double mPurePursuitReverseGain;
 
     double getCurvatureWithTrailer(const QPointF &point);
 };

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -32,9 +32,13 @@ public:
     // Override the updateOdomPositionAndYaw function to consider the angle of the trailer
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
 
+    double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
+
     QSharedPointer<TrailerState> getTrailerState() const { return mTrailerState; }
     void setTrailerState(QSharedPointer<TrailerState> newTrailerState) { mTrailerState=newTrailerState; }
 
+    bool getHasTrailer() const ;
+    void setHasTrailer(bool mHasTrailer);
 
 #ifdef QT_GUI_LIB
     // Override or add drawing functions if needed (to draw a truck)
@@ -47,6 +51,9 @@ private:
     double mTrailerAngleDegress; // Angle in Degrees
     double mtrailerwheelbase; // trailer wheelbase
     QSharedPointer<TrailerState> mTrailerState; // trailer created dynamically
+    bool mHasTrailer = false;
+
+    double getCurvatureWithTrailer(const QPointF &point);
 };
 
 #endif // TRUCKSTATE_H


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add functionality to pure pursuit to calculate curvature with a trailer


* **What is the current behavior?** (You can also link to an open issue here)
The pure pursuit does not take into account type of vehicle


* **What is the new behavior (if this is a feature change)?**

Pure pursuit will check if the type is truckstate and call a different function to calculate the  


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, the RRCar needs to add WayWise/vehicles/truckstate.cpp to CMakeLists.txt in order to compile,
this does not look optimal, but I don't know a work around for the moment


* **Other information**:

