### PR TITLE
Fix/driveui for controltower

### DIFF
--- a/userinterface/driveui.cpp
+++ b/userinterface/driveui.cpp
@@ -112,6 +112,17 @@ void DriveUI::on_apStopButton_clicked()
     }
 }
 
+
+void DriveUI::setIsDriveUiVisible(const bool value)
+{
+    isDriveUiVisible = value;
+}
+
+bool DriveUI::getIsDriveUiVisible()
+{
+    return isDriveUiVisible;
+}
+
 void DriveUI::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {

--- a/userinterface/driveui.cpp
+++ b/userinterface/driveui.cpp
@@ -125,41 +125,49 @@ bool DriveUI::getIsDriveUiVisible()
 
 void DriveUI::keyPressEvent(QKeyEvent *event)
 {
-    switch (event->key()) {
-    case Qt::Key_Up:
-        mArrowKeyStates.upPressed = true;
-        break;
-    case Qt::Key_Down:
-        mArrowKeyStates.downPressed = true;
-        break;
-    case Qt::Key_Left:
-        mArrowKeyStates.leftPressed = true;
-        break;
-    case Qt::Key_Right:
-        mArrowKeyStates.rightPressed = true;
-        break;
-    default:
-        break;
+    if (isDriveUiVisible) {
+        switch (event->key()) {
+        case Qt::Key_Up:
+            mArrowKeyStates.upPressed = true;
+            break;
+        case Qt::Key_Down:
+            mArrowKeyStates.downPressed = true;
+            break;
+        case Qt::Key_Left:
+            mArrowKeyStates.leftPressed = true;
+            break;
+        case Qt::Key_Right:
+            mArrowKeyStates.rightPressed = true;
+            break;
+        default:
+            break;
+        }
+    } else {
+        event->ignore();
     }
 }
 
 void DriveUI::keyReleaseEvent(QKeyEvent *event)
 {
-    switch (event->key()) {
-    case Qt::Key_Up:
-        mArrowKeyStates.upPressed = false;
-        break;
-    case Qt::Key_Down:
-        mArrowKeyStates.downPressed = false;
-        break;
-    case Qt::Key_Left:
-        mArrowKeyStates.leftPressed = false;
-        break;
-    case Qt::Key_Right:
-        mArrowKeyStates.rightPressed = false;
-        break;
-    default:
-        break;
+    if (isDriveUiVisible) {
+        switch (event->key()) {
+        case Qt::Key_Up:
+            mArrowKeyStates.upPressed = false;
+            break;
+        case Qt::Key_Down:
+            mArrowKeyStates.downPressed = false;
+            break;
+        case Qt::Key_Left:
+            mArrowKeyStates.leftPressed = false;
+            break;
+        case Qt::Key_Right:
+            mArrowKeyStates.rightPressed = false;
+            break;
+        default:
+            break;
+        }
+    } else {
+        event->ignore();
     }
 }
 

--- a/userinterface/driveui.h
+++ b/userinterface/driveui.h
@@ -29,6 +29,9 @@ public:
     void setCurrentVehicleConnection(const QSharedPointer<VehicleConnection> &currentVehicleConnection);
     void gotRouteForAutopilot(const QList<PosPoint>& route);
 
+    void setIsDriveUiVisible(const bool value);
+    bool getIsDriveUiVisible();
+
 private slots:
     void on_apRestartButton_clicked();
 
@@ -56,6 +59,7 @@ private:
     struct {bool upPressed, downPressed, leftPressed, rightPressed;} mArrowKeyStates;
     struct {double throttle, steering;} mKeyControlState;
     QTimer mKeyControlTimer;
+    bool isDriveUiVisible;
 
     double getMaxSignedStepFromValueTowardsGoal(double value, double goal, double maxStepSize);
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Bug fix/feature

* **What is the current behavior?** (You can also link to an open issue here)

  Currently the manual control with driveui is active even when the tab is not visible. IMO this feature should be active only when driveui is visible.

* **What is the new behavior (if this is a feature change)?**

  The key press and release events are processed only when driveui is visible.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  Yes, setIsDriveUiVisible() method should be called appropriately to get manual control to work.

* **Other information**:


