### PR TITLE
Visualize truck and trailer on control tower

### DIFF
--- a/autopilot/followpoint.cpp
+++ b/autopilot/followpoint.cpp
@@ -17,10 +17,10 @@ FollowPoint::FollowPoint(QSharedPointer<MovementController> movementController)
 
     // Provide parameters to ControlTower
     if (ParameterServer::getInstance()) {
-        ParameterServer::getInstance()->provideParameter("FP_DIST", std::bind(&FollowPoint::setFollowPointDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointDistance, this));
-        ParameterServer::getInstance()->provideParameter("FP_MAX_DIST", std::bind(&FollowPoint::setFollowPointMaximumDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointMaximumDistance, this));
-        ParameterServer::getInstance()->provideParameter("FP_SPEED", std::bind(&FollowPoint::setFollowPointSpeed, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointSpeed, this));
-        ParameterServer::getInstance()->provideParameter("FP_AP_RADIUS", std::bind(&FollowPoint::setAutopilotRadius, this, std::placeholders::_1), std::bind(&FollowPoint::getAutopilotRadius, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP_DIST", std::bind(&FollowPoint::setFollowPointDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointDistance, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP_MAX_DIST", std::bind(&FollowPoint::setFollowPointMaximumDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointMaximumDistance, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP_SPEED", std::bind(&FollowPoint::setFollowPointSpeed, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointSpeed, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP_AP_RADIUS", std::bind(&FollowPoint::setAutopilotRadius, this, std::placeholders::_1), std::bind(&FollowPoint::getAutopilotRadius, this));
 
     }
 }
@@ -40,10 +40,10 @@ FollowPoint::FollowPoint(QSharedPointer<VehicleConnection> vehicleConnection, Po
     // Provide parameters to ControlTower
     std::string id = std::to_string(mVehicleState->getId());
     if (ParameterServer::getInstance()) {
-        ParameterServer::getInstance()->provideParameter("FP"+id+"_DIST", std::bind(&FollowPoint::setFollowPointDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointDistance, this));
-        ParameterServer::getInstance()->provideParameter("FP"+id+"_MAX_DIST", std::bind(&FollowPoint::setFollowPointMaximumDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointMaximumDistance, this));
-        ParameterServer::getInstance()->provideParameter("FP"+id+"_HEIGHT", std::bind(&FollowPoint::setFollowPointHeight, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointHeight, this));
-        ParameterServer::getInstance()->provideParameter("FP"+id+"_ANGLE_DEG", std::bind(&FollowPoint::setFollowPointAngleInDeg, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointAngleInDeg, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP"+id+"_DIST", std::bind(&FollowPoint::setFollowPointDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointDistance, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP"+id+"_MAX_DIST", std::bind(&FollowPoint::setFollowPointMaximumDistance, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointMaximumDistance, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP"+id+"_HEIGHT", std::bind(&FollowPoint::setFollowPointHeight, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointHeight, this));
+        ParameterServer::getInstance()->provideFloatParameter("FP"+id+"_ANGLE_DEG", std::bind(&FollowPoint::setFollowPointAngleInDeg, this, std::placeholders::_1), std::bind(&FollowPoint::getFollowPointAngleInDeg, this));
 
     }
 }

--- a/autopilot/multiwaypointfollower.cpp
+++ b/autopilot/multiwaypointfollower.cpp
@@ -116,10 +116,10 @@ int MultiWaypointFollower::addWaypointFollower(QSharedPointer<WaypointFollower> 
 
     // Provide system parameters to ControlTower
     if (ParameterServer::getInstance()) {
-        ParameterServer::getInstance()->provideParameter("PPRadius", std::bind(&MultiWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1),
-                                                         std::bind(&MultiWaypointFollower::getPurePursuitRadius, this));
-        ParameterServer::getInstance()->provideParameter("APPRC", std::bind(&MultiWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1),
-                                                         std::bind(&MultiWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+        ParameterServer::getInstance()->provideFloatParameter("PP_RADIUS", std::bind(&MultiWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1),
+                                                        std::bind(&MultiWaypointFollower::getPurePursuitRadius, this));
+        ParameterServer::getInstance()->provideFloatParameter("PP_ARC", std::bind(&MultiWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1),
+                                                        std::bind(&MultiWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
     }
 
     return (getNumberOfWaypointFollowers() - 1) ;

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -19,8 +19,8 @@ PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<Movement
 
     // Provide system parameters to ControlTower
     if (ParameterServer::getInstance()) {
-        ParameterServer::getInstance()->provideParameter("PP_RADIUS", std::bind(&PurepursuitWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getPurePursuitRadius, this));
-        ParameterServer::getInstance()->provideParameter("PP_ARC", std::bind(&PurepursuitWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
+        ParameterServer::getInstance()->provideFloatParameter("PP_RADIUS", std::bind(&PurepursuitWaypointFollower::setPurePursuitRadius, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getPurePursuitRadius, this));
+        ParameterServer::getInstance()->provideFloatParameter("PP_ARC", std::bind(&PurepursuitWaypointFollower::setAdaptivePurePursuitRadiusCoefficient, this, std::placeholders::_1), std::bind(&PurepursuitWaypointFollower::getAdaptivePurePursuitRadiusCoefficient, this));
     }
 }
 

--- a/communication/mavlinkparameterserver.cpp
+++ b/communication/mavlinkparameterserver.cpp
@@ -34,10 +34,17 @@ void MavlinkParameterServer::initialize(std::shared_ptr<mavsdk::ServerComponent>
  * @param parameterName
  * Parameter names must be no more than 16 ASCII characters
  */
-void MavlinkParameterServer::provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction)
+void MavlinkParameterServer::provideIntParameter(std::string parameterName, std::function<void(int)> setClassParameterFunction, std::function<int(void)> getClassParameterFunction)
 {
     const std::lock_guard<std::mutex> lock(mMutex);
-    mParameterToClassMapping.insert_or_assign(parameterName, std::make_pair(setClassParameterFunction, getClassParameterFunction));
+    mIntParameterToClassMapping.insert_or_assign(parameterName, std::make_pair(setClassParameterFunction, getClassParameterFunction));
+    mMavsdkParamServer->provide_param_int(parameterName, getClassParameterFunction());
+};
+
+void MavlinkParameterServer::provideFloatParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction)
+{
+    const std::lock_guard<std::mutex> lock(mMutex);
+    mFloatParameterToClassMapping.insert_or_assign(parameterName, std::make_pair(setClassParameterFunction, getClassParameterFunction));
     mMavsdkParamServer->provide_param_float(parameterName, getClassParameterFunction());
 };
 

--- a/communication/mavlinkparameterserver.h
+++ b/communication/mavlinkparameterserver.h
@@ -16,7 +16,8 @@ class MavlinkParameterServer : public ParameterServer
     Q_OBJECT
 public:
     static void initialize(std::shared_ptr<mavsdk::ServerComponent> serverComponent);
-    virtual void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction) override;
+    virtual void provideIntParameter(std::string parameterName, std::function<void(int)> setClassParameterFunction, std::function<int(void)> getClassParameterFunction) override;
+    virtual void provideFloatParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction) override;
     virtual void saveParametersToXmlFile(QString filename) override;
 
 protected:

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -439,6 +439,10 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         qDebug() << "MavsdkVehicleServer is listening on" << controlTowerAddress.toString() << "with port" << controlTowerPort;
 
     ParameterServer::getInstance()->provideFloatParameter("MC_MAX_SPEED_MS", std::bind(&MavsdkVehicleServer::setManualControlMaxSpeed, this, std::placeholders::_1), std::bind(&MavsdkVehicleServer::getManualControlMaxSpeed, this));
+    ParameterServer::getInstance()->provideIntParameter("VEH_WW_OBJ_TYPE",
+        std::function<void(int)>([this](int value) {this->mVehicleState->setWaywiseObjectType(static_cast<WAYWISE_OBJECT_TYPE>(value));}),
+        std::function<int(void)>([this]() {return static_cast<int>(this->mVehicleState->getWaywiseObjectType());})
+    );
 }
 
 void MavsdkVehicleServer::heartbeatTimeout() {

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -438,7 +438,7 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
     if (result == mavsdk::ConnectionResult::Success)
         qDebug() << "MavsdkVehicleServer is listening on" << controlTowerAddress.toString() << "with port" << controlTowerPort;
 
-    ParameterServer::getInstance()->provideParameter("MC_MAX_SPEED_MS", std::bind(&MavsdkVehicleServer::setManualControlMaxSpeed, this, std::placeholders::_1), std::bind(&MavsdkVehicleServer::getManualControlMaxSpeed, this));
+    ParameterServer::getInstance()->provideFloatParameter("MC_MAX_SPEED_MS", std::bind(&MavsdkVehicleServer::setManualControlMaxSpeed, this, std::placeholders::_1), std::bind(&MavsdkVehicleServer::getManualControlMaxSpeed, this));
 }
 
 void MavsdkVehicleServer::heartbeatTimeout() {

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -405,8 +405,14 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         case MAVLINK_MSG_ID_PARAM_VALUE: // This message is sent when a parameter has been changed
             mavlink_param_value_t parameter;
             mavlink_msg_param_value_decode(&message, &parameter);
-            if (parameter.param_type == 9) // Float
-                mParameterServer->updateParameter(parameter.param_id, parameter.param_value);
+            if (parameter.param_type == MAV_PARAM_TYPE_REAL32) // Float
+                mParameterServer->updateFloatParameter(parameter.param_id, (float) parameter.param_value);
+            else if (parameter.param_type == MAV_PARAM_TYPE_INT32) // Int
+            {
+                mavlink_param_union_t param;
+                param.param_float = parameter.param_value;
+                mParameterServer->updateIntParameter(parameter.param_id, (int) param.param_int32);
+            }
             break;
         default: ;
 //            qDebug() << "out:" << message.msgid;

--- a/communication/parameterserver.h
+++ b/communication/parameterserver.h
@@ -8,6 +8,8 @@
 
 #include <QObject>
 #include <mutex>
+#include <unordered_map>
+#include <functional>
 
 class ParameterServer : public QObject
 {
@@ -26,16 +28,17 @@ public:
         std::string value{};
     };
     struct AllParameters {
-        std::vector<IntParameter>
-            intParameters{};
+        std::vector<IntParameter> intParameters{};
         std::vector<FloatParameter> floatParameters{};
         std::vector<CustomParameter> customParameters{};
     };
 
     static void initialize();
     static ParameterServer* getInstance();
-    bool updateParameter(std::string parameterName, float parameterValue);
-    virtual void provideParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction);
+    bool updateIntParameter(std::string parameterName, int parameterValue);
+    bool updateFloatParameter(std::string parameterName, float parameterValue);
+    virtual void provideIntParameter(std::string parameterName, std::function<void(int)> setClassParameterFunction, std::function<int(void)> getClassParameterFunction);
+    virtual void provideFloatParameter(std::string parameterName, std::function<void(float)> setClassParameterFunction, std::function<float(void)> getClassParameterFunction);
     virtual void saveParametersToXmlFile(QString filename);
     AllParameters getAllParameters();
 
@@ -44,7 +47,8 @@ protected:
     virtual ~ParameterServer(){};
     static ParameterServer *mInstancePtr;
     std::mutex mMutex;
-    std::unordered_map<std::string, std::pair<std::function<void(float)>, std::function<float(void)>>> mParameterToClassMapping;
+    std::unordered_map<std::string, std::pair<std::function<void(int)>, std::function<int(void)>>> mIntParameterToClassMapping;
+    std::unordered_map<std::string, std::pair<std::function<void(float)>, std::function<float(void)>>> mFloatParameterToClassMapping;
 };
 
 #endif // PARAMETERSERVER_H

--- a/communication/vehicleconnections/mavsdkvehicleconnection.cpp
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.cpp
@@ -14,6 +14,9 @@ MavsdkVehicleConnection::MavsdkVehicleConnection(std::shared_ptr<mavsdk::System>
     mVehicleType = vehicleType;
     mMavlinkPassthrough.reset(new mavsdk::MavlinkPassthrough(system));
 
+    // Set up param plugin
+    mParam.reset(new mavsdk::Param(mSystem));
+
     // Setup gimbal
     mComponentDiscoveredHandle = mSystem->subscribe_component_discovered([this](mavsdk::System::ComponentType){
         if (mSystem->has_gimbal() && mGimbal.isNull()) {
@@ -31,11 +34,49 @@ MavsdkVehicleConnection::MavsdkVehicleConnection(std::shared_ptr<mavsdk::System>
         mVehicleState->setName("Copter " + QString::number(mSystem->get_system_id()));
         break;
     case MAV_TYPE_GROUND_ROVER:
-        qDebug() << "MavsdkVehicleConnection: we are talking to a MAV_TYPE_GROUND_ROVER / WayWise.";
-        // TODO: detect different rover types...
-        mVehicleState = QSharedPointer<CarState>::create(mSystem->get_system_id());
-        mVehicleState->setName("Car " + QString::number(mSystem->get_system_id()));
-        break;
+        {
+            WAYWISE_OBJECT_TYPE mWaywiseObjectType = WAYWISE_OBJECT_TYPE_CAR;
+            auto waywiseObjTypeParamResult = getIntParameterFromVehicle("VEH_WW_OBJ_TYPE");
+            if (waywiseObjTypeParamResult.first == VehicleConnection::Result::Success) {
+                mWaywiseObjectType = static_cast<WAYWISE_OBJECT_TYPE>(waywiseObjTypeParamResult.second);
+                if (!(mWaywiseObjectType == WAYWISE_OBJECT_TYPE_TRUCK || mWaywiseObjectType == WAYWISE_OBJECT_TYPE_CAR)){
+                    qDebug() << "VEH_WW_OBJ_TYPE param is set to unsupported type for MAV_TYPE_GROUND_ROVER. We asuume that it is a car type.";
+                    mWaywiseObjectType = WAYWISE_OBJECT_TYPE_CAR;
+                }
+            }
+
+            switch (mWaywiseObjectType) {
+                case WAYWISE_OBJECT_TYPE_TRUCK:
+                {
+                    qDebug() << "MavsdkVehicleConnection: we are talking to a MAV_TYPE_GROUND_ROVER / WayWise Truck.";
+                    setupTruckState();
+                    break;
+                }
+                default:
+                {
+                    qDebug() << "MavsdkVehicleConnection: we are talking to a MAV_TYPE_GROUND_ROVER / WayWise Car.";
+                    mVehicleState = QSharedPointer<CarState>::create(mSystem->get_system_id());
+                    mVehicleState->setName("Car " + QString::number(mSystem->get_system_id()));
+
+                    QSharedPointer<CarState> mCarState = qSharedPointerDynamicCast<CarState>(mVehicleState);
+                    auto vehicleParamResult = getFloatParameterFromVehicle("VEH_LENGTH");
+                    if (vehicleParamResult.first == VehicleConnection::Result::Success) {
+                        mCarState->setLength(vehicleParamResult.second);
+                    }
+                    vehicleParamResult = getFloatParameterFromVehicle("VEH_WIDTH");
+                    if (vehicleParamResult.first == VehicleConnection::Result::Success) {
+                        mCarState->setWidth(vehicleParamResult.second);
+                    }
+                    vehicleParamResult = getFloatParameterFromVehicle("VEH_WHLBASE");
+                    if (vehicleParamResult.first == VehicleConnection::Result::Success) {
+                        mCarState->setAxisDistance(vehicleParamResult.second);
+                    }
+                    break;
+                }
+            }
+
+            break;
+        }
     default:
         qDebug() << "MavsdkVehicleConnection: unknown / unsupported vehicle type.";
         break;
@@ -233,9 +274,6 @@ MavsdkVehicleConnection::MavsdkVehicleConnection(std::shared_ptr<mavsdk::System>
     // Set up action plugin
     mAction.reset(new mavsdk::Action(mSystem));
 
-    // Set up param plugin
-    mParam.reset(new mavsdk::Param(mSystem));
-
 // TODO: this should not happen here (blocking)
 //    // Precision Landing: set required target tracking accuracy for starting approach
 //    if (mParam->set_param_float("PLD_HACC_RAD", 5.0) != mavsdk::Param::Result::Success)
@@ -243,6 +281,67 @@ MavsdkVehicleConnection::MavsdkVehicleConnection(std::shared_ptr<mavsdk::System>
 
     // Necessary such that MAVSDK callbacks (from other threads) can stop WaypointFollower (QTimer)
     connect(this, &MavsdkVehicleConnection::stopWaypointFollowerSignal, this, &MavsdkVehicleConnection::stopAutopilot);
+}
+
+void MavsdkVehicleConnection::setupTruckState()
+{
+    mVehicleState = QSharedPointer<TruckState>::create(mSystem->get_system_id());
+    mVehicleState->setName("Truck " + QString::number(mSystem->get_system_id()));
+
+    QSharedPointer<TruckState> mTruckState = qSharedPointerDynamicCast<TruckState>(mVehicleState);
+    auto vehicleParamResult = getFloatParameterFromVehicle("VEH_LENGTH");
+    if (vehicleParamResult.first == VehicleConnection::Result::Success) {
+        mTruckState->setLength(vehicleParamResult.second);
+    }
+    vehicleParamResult = getFloatParameterFromVehicle("VEH_WIDTH");
+    if (vehicleParamResult.first == VehicleConnection::Result::Success) {
+        mTruckState->setWidth(vehicleParamResult.second);
+    }
+    vehicleParamResult = getFloatParameterFromVehicle("VEH_WHLBASE");
+    if (vehicleParamResult.first == VehicleConnection::Result::Success) {
+        mTruckState->setAxisDistance(vehicleParamResult.second);
+    }
+
+    auto trailerParamResult = getIntParameterFromVehicle("TRLR_COMP_ID");
+    if (trailerParamResult.first == VehicleConnection::Result::Success) {
+        int trailer_component_id = trailerParamResult.second;
+        if (trailer_component_id>=0) {
+            // Setup Trailer
+            mavsdk::System::ComponentDiscoveredIdHandle mComponentDiscoveredIdHandle = mSystem->subscribe_component_discovered_id([this, mTruckState, trailer_component_id](mavsdk::System::ComponentType component_type, uint8_t component_id){
+                if (component_type == mavsdk::System::ComponentType::UNKNOWN && component_id == (uint8_t) trailer_component_id) {
+                    qDebug() << "Trailer discovered with system ID "<< mSystem->get_system_id() << " and component ID "<< component_id;
+                    mTruckState->setTrailerState(QSharedPointer<TrailerState>::create(component_id));
+                    QSharedPointer<TrailerState> mTrailerState = mTruckState->getTrailerState();
+                    mTrailerState->setName("Trailer " + QString::number(mSystem->get_system_id()));
+
+                    auto trailerParamResult = getFloatParameterFromVehicle("TRLR_LENGTH");
+                    if (trailerParamResult.first == VehicleConnection::Result::Success) {
+                        mTrailerState->setLength(trailerParamResult.second);
+                    }
+                    trailerParamResult = getFloatParameterFromVehicle("TRLR_WIDTH");
+                    if (trailerParamResult.first == VehicleConnection::Result::Success) {
+                        mTrailerState->setWidth(trailerParamResult.second);
+                    }
+                    trailerParamResult = getFloatParameterFromVehicle("TRLR_WHLBASE");
+                    if (trailerParamResult.first == VehicleConnection::Result::Success) {
+                        mTrailerState->setWheelBase(trailerParamResult.second);
+                    }
+
+                    mMavlinkPassthrough->subscribe_message(MAVLINK_MSG_ID_ATTITUDE, [this, mTruckState, component_id](const mavlink_message_t &message) {
+                    if (message.compid == component_id) {
+                        mavlink_attitude_t attitude_data;
+                        mavlink_msg_attitude_decode(&message, &attitude_data);
+
+                        // Extract yaw value from attitude message
+                        double angle_in_radians = (mTruckState->getPosition().getYaw() * (M_PI / 180.0)) - attitude_data.yaw;
+                        double angle_in_degrees = angle_in_radians * (180.0 / M_PI);
+                        mTruckState->setTrailerAngle(0, angle_in_radians, angle_in_degrees); // raw_angle is not currently used
+                    }
+                });
+                }
+            });
+        }
+    }
 }
 
 void MavsdkVehicleConnection::setEnuReference(const llh_t &enuReference)

--- a/communication/vehicleconnections/mavsdkvehicleconnection.h
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.h
@@ -19,6 +19,7 @@
 //#include "autopilot/purepursuitwaypointfollower.h"
 #include "vehicles/copterstate.h"
 #include "vehicles/carstate.h"
+#include "vehicles/truckstate.h"
 #include "sensors/camera/mavsdkgimbal.h"
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/telemetry/telemetry.h>
@@ -96,6 +97,7 @@ private:
     VehicleConnection::Result convertParamResult(mavsdk::Param::Result result) const;
     QString convertMissionRawResult(mavsdk::MissionRaw::Result result) const;
     QString convertMavlinkPassthroughResult(mavsdk::MavlinkPassthrough::Result result) const;
+    void setupTruckState();
 
     // VehicleConnection interface
 protected:

--- a/userinterface/map/mapwidget.cpp
+++ b/userinterface/map/mapwidget.cpp
@@ -400,6 +400,11 @@ QList<QSharedPointer<ObjectState> > MapWidget::getObjectStateList() const
     return mObjectStateMap.values();
 }
 
+bool MapWidget::setTileServerUrl(QString path)
+{
+    return mOsm->setTileServerUrl(path);
+}
+
 void MapWidget::addMapModule(QSharedPointer<MapModule> m)
 {
     mMapModules.append(m);

--- a/userinterface/map/mapwidget.h
+++ b/userinterface/map/mapwidget.h
@@ -106,6 +106,8 @@ public:
 
     QList<QSharedPointer<ObjectState>> getObjectStateList() const;
 
+    bool setTileServerUrl(QString path);
+
 signals:
     void scaleChanged(double newScale);
     void offsetChanged(double newXOffset, double newYOffset);

--- a/vehicles/carstate.cpp
+++ b/vehicles/carstate.cpp
@@ -13,7 +13,7 @@
 
 CarState::CarState(ObjectID_t id, Qt::GlobalColor color) : VehicleState(id, color)
 {
-
+    ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_CAR);
 }
 
 #ifdef QT_GUI_LIB

--- a/vehicles/copterstate.cpp
+++ b/vehicles/copterstate.cpp
@@ -17,6 +17,8 @@ CopterState::CopterState(ObjectID_t id, Qt::GlobalColor color) : VehicleState(id
     mPropellerSize = 260;
     setWidth(520);
     setLength(520);
+
+    ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_QUADCOPTER);
 }
 
 void CopterState::draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected)

--- a/vehicles/objectstate.h
+++ b/vehicles/objectstate.h
@@ -21,6 +21,14 @@
 
 #include "core/pospoint.h"
 #include <math.h>
+typedef enum WAYWISE_OBJECT_TYPE
+{
+    WAYWISE_OBJECT_TYPE_GENERIC=0, /* Generic object | */
+    WAYWISE_OBJECT_TYPE_CAR=1, /* Car. | */
+    WAYWISE_OBJECT_TYPE_TRUCK=2, /* Truck | */
+    WAYWISE_OBJECT_TYPE_TRAILER=3, /* Trailer | */
+    WAYWISE_OBJECT_TYPE_QUADCOPTER=4, /* Quadcopter | */
+} WAYWISE_OBJECT_TYPE;
 
 class ObjectState : public QObject
 {
@@ -42,6 +50,8 @@ public:
     void setName(const QString& name) { mName = name; }
     Qt::GlobalColor getColor() const { return mColor; }
     void setColor(const Qt::GlobalColor color) { mColor = color; }
+    WAYWISE_OBJECT_TYPE getWaywiseObjectType() const { return mWaywiseObjectType; }
+    void setWaywiseObjectType(const WAYWISE_OBJECT_TYPE value) { mWaywiseObjectType = value; }
 
     // Dynamic state
     virtual PosPoint getPosition() const { return mPosition; }
@@ -67,6 +77,7 @@ private:
     QString mName;
     Qt::GlobalColor mColor;
     bool mDrawStatusText = true;
+    WAYWISE_OBJECT_TYPE mWaywiseObjectType = WAYWISE_OBJECT_TYPE_GENERIC;
 
 protected:
     // Dynamic state

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -46,6 +46,8 @@ void TrailerState::drawTrailer(QPainter &painter, const QTransform &drawTrans, c
 void TrailerState::draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected){
     // draw a trailer indepentently
 
+    (void)txtTrans;
+    (void)isSelected;
     PosPoint pos = getPosition();
     double x = pos.getX() * 1000.0  ;// convert from m to mm (on the map objects are in mm)
     double y = pos.getY() * 1000.0  ;

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -13,6 +13,8 @@ TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : ObjectState (
     mLength = 0.96; // griffin specific
     mWidth = 0.21;  // griffin specific
 
+    ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_TRAILER);
+
 }
 
 #ifdef QT_GUI_LIB

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -12,6 +12,7 @@
 TruckState::TruckState(ObjectID_t id, Qt::GlobalColor color) : CarState(id, color)
 {
     // Additional initialization if needed for the TruckState
+    ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_TRUCK);
 }
 
 void TruckState::updateOdomPositionAndYaw(double drivenDistance, PosType usePosType)

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -142,9 +142,6 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     if (!mTrailerState.isNull()) {
         double angleInDegrees = getTrailerAngleDegrees();
         mTrailerState->drawTrailer(painter,drawTrans, pos, angleInDegrees);
-    } else {
-        // mTrailerState is empty
-        qDebug() << "WARN: Trailer is empty";
     }
 
     painter.restore();
@@ -162,7 +159,7 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     double trailerAngle  = getTrailerAngleRadians();
     double currYaw_rad = getPosition().getYaw() * (M_PI/180.0);
     double trailerYaw = currYaw_rad- trailerAngle;
-    double trailerAxis = getTrailerWheelBase;
+    double trailerAxis = getTrailerWheelBase();
     double dx = trailerAxis * cos(trailerYaw);
     double dy = trailerAxis * sin(trailerYaw);
     double newX = (pos.getX() - dx) *1000.0;
@@ -180,19 +177,6 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     QString txt;
     QPointF pt_txt;
     QRectF rect_txt;
-
-    QTextStream txtStream(&txt);
-    txtStream.setRealNumberPrecision(3);
-    txtStream << "Trailer: " << Qt::endl
-              << "(" << pos.getX()- dx << ", " << pos.getY()- dy << ", "
-              << trailerYaw / (M_PI/180.0)<< ")" << Qt::endl;
-    pt_txt.setX(newX + truck_w + truck_len * ((cos(trailerYaw) - 1) / 3));
-    pt_txt.setY(newY);
-    painter.setTransform(txtTrans);
-    pt_txt = drawTrans.map(pt_txt);
-    rect_txt.setCoords(pt_txt.x(), pt_txt.y() - 40,
-                           pt_txt.x() + 400, pt_txt.y() + 65);
-    painter.drawText(rect_txt, txt);
 
     if (getDrawStatusText()) {
         // Print data
@@ -222,10 +206,14 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
         QTextStream txtStream(&txt);
         txtStream.setRealNumberPrecision(3);
         txtStream << getName() << Qt::endl
-                  << "(" << pos.getX() << ", " << pos.getY() << ", " << pos.getHeight() << ", " << (int)pos.getYaw() << ")" << Qt::endl
+                  << "(" << pos.getX() << ", " << pos.getY() << ", " << pos.getHeight() << ", " << pos.getYaw() << ")" << Qt::endl
                   << "State: " << (getIsArmed() ? "armed" : "disarmed") << Qt::endl
-                  << flightModeStr;
-
+                  << flightModeStr << Qt::endl << Qt::endl;
+        if (!mTrailerState.isNull()) {
+            txtStream << mTrailerState->getName() << Qt::endl
+                    << "(" << pos.getX()- dx << ", " << pos.getY()- dy << ", " << pos.getHeight() << ", "
+                    << trailerYaw * (180.0/M_PI)<< ")" << Qt::endl;
+        }
         pt_txt.setX(x + truck_w + truck_len * ((cos(getPosition().getYaw() * (M_PI/180.0)) + 1) / 3));
         pt_txt.setY(y);
         painter.setTransform(txtTrans);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

truck is initialized with carstate on the control tower. There is no way to differentiate between car and truck when identifying the Mavsdk system at the control tower.

* **What is the new behavior (if this is a feature change)?**

An enum is defined in objectstate to specify vehicle object type. The vehicle server provides this object type which is read by the control tower to differentiate between truck and car. Additionally, the truck-trailer hitch angle is sent to the control tower via Mavlink. Car, Truck and Trailer dimensions are configurable via parameters.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

The controltower build fails are due to missing truckstate and trailerstate sources in its cmakelist.
