### PR TITLE
modify purepursuit when their is a trailer in reverse to take the poi…

### DIFF
--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -22,6 +22,8 @@ public:
     double getTrailerAngleRadians() const { return mTrailerAngleRadians; }
     double getTrailerAngleDegrees() const { return mTrailerAngleDegress; }
     double getTrailerWheelBase() const { return mtrailerwheelbase; }
+    void setTrailerWheelBase ( double value ){ mtrailerwheelbase =value;}
+
 
     void setTrailerAngle(uint16_t raw_angle , double angle_in_radians, double agnle_in_degrees);
 


### PR DESCRIPTION
…nts from the wheelbase

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
I add an if statement in pure-pursuit to check when we have a truck in reverse to take the points from the wheelbase


* **What is the current behavior?** (You can also link to an open issue here)
The  pure-pursuit algorithm when a truck is in reverse it takes the points from the truck instead of the trailer


* **What is the new behavior (if this is a feature change)?**
The  pure-pursuit algorithm when a truck is in reverse it takes the points from the trailer


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes , I add a new function to TruckState it affects only Griffin repo and WayWiserR truck script


* **Other information**:


