### PR TITLE
PurepursuitWaypointFollower: take trailer position when backing

### DIFF
--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -9,7 +9,6 @@
 #include "purepursuitwaypointfollower.h"
 #include "communication/parameterserver.h"
 #include "core/geometry.h"
-#include "WayWise/vehicles/truckstate.h"
 
 PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<MovementController> movementController)
 {
@@ -128,26 +127,12 @@ void PurepursuitWaypointFollower::updateState()
 
     case WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING: {
         calculateDistanceOfRouteLeft();
-        currentVehiclePositionXY = mVehicleState->getPosition(mPosTypeUsed).getPoint();
-        if(mMovementController->getVehicleState()->getSpeed() < 0){
-            auto truckState = qSharedPointerDynamicCast<TruckState>(mMovementController->getVehicleState());
-            if(truckState){
-                double currYaw_rad = mVehicleState->getPosition(mPosTypeUsed).getYaw() * M_PI / 180.0;
-                double trailerAngle = truckState->getTrailerAngleRadians();
-                double trailerAxis = qSharedPointerDynamicCast<TrailerState>(truckState->getTrailingVehicle())->getWheelBase();
-                double trailerYaw = currYaw_rad - trailerAngle ; // in radians θ = θ_vehicle - θ_e (hitch-angle)
-                trailerYaw = fmod(trailerYaw + M_PI, 2 * M_PI) - M_PI;
-                double delta_x_ = (trailerAxis) * cos( trailerYaw); // trailer x difference from x of the truck wheelbase
-                double delta_y = (trailerAxis) * sin( trailerYaw); // trailer y difference from y of the truck wheelbase
+        if (mVehicleState->hasTrailingVehicle() && mVehicleState->getSpeed() < 0) // position defined by trailer when backing (if exists)
+            currentVehiclePositionXY = mVehicleState->getTrailingVehicle()->getPosition().getPoint();
+        else
+            currentVehiclePositionXY = mVehicleState->getPosition(mPosTypeUsed).getPoint();
 
-                // double delta_x_ = trailerAxis * cos(currYaw_rad- trailerAngle);
-                // double delta_y = trailerAxis * sin(currYaw_rad - trailerAngle);
-                currentVehiclePositionXY.setX( currentVehiclePositionXY.x() - delta_x_ );
-                currentVehiclePositionXY.setY( currentVehiclePositionXY.y() - delta_y );                
-            }
-        }
         QPointF currentWaypointPoint = mWaypointList.at(mCurrentState.currentWaypointIndex).getPoint();
-
         if (QLineF(currentVehiclePositionXY, currentWaypointPoint).length() < purePursuitRadius()) // consider previous waypoint as reached
             mCurrentState.currentWaypointIndex++;
 

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -134,7 +134,7 @@ void PurepursuitWaypointFollower::updateState()
             if(truckState){
                 double currYaw_rad = mVehicleState->getPosition(mPosTypeUsed).getYaw() * M_PI / 180.0;
                 double trailerAngle = truckState->getTrailerAngleRadians();
-                double trailerAxis = truckState->getTrailerState()->getWheelBase();
+                double trailerAxis = qSharedPointerDynamicCast<TrailerState>(truckState->getTrailingVehicle())->getWheelBase();
                 double trailerYaw = currYaw_rad - trailerAngle ; // in radians θ = θ_vehicle - θ_e (hitch-angle)
                 trailerYaw = fmod(trailerYaw + M_PI, 2 * M_PI) - M_PI;
                 double delta_x_ = (trailerAxis) * cos( trailerYaw); // trailer x difference from x of the truck wheelbase

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -134,7 +134,7 @@ void PurepursuitWaypointFollower::updateState()
             if(truckState){
                 double currYaw_rad = mVehicleState->getPosition(mPosTypeUsed).getYaw() * M_PI / 180.0;
                 double trailerAngle = truckState->getTrailerAngleRadians();
-                double trailerAxis = truckState->  getTrailerWheelBase ();
+                double trailerAxis = truckState->getTrailerState()->getWheelBase();
                 double trailerYaw = currYaw_rad - trailerAngle ; // in radians θ = θ_vehicle - θ_e (hitch-angle)
                 trailerYaw = fmod(trailerYaw + M_PI, 2 * M_PI) - M_PI;
                 double delta_x_ = (trailerAxis) * cos( trailerYaw); // trailer x difference from x of the truck wheelbase

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -87,7 +87,7 @@ private:
     QTimer mUpdateStateTimer;
 
     void holdPosition();
-    void calculateDistanceOfRouteLeft();
+    void calculateDistanceOfRouteLeft(QPointF currentVehiclePositionXY);
     double purePursuitRadius();
 };
 

--- a/sensors/angle/as5600updater.cpp
+++ b/sensors/angle/as5600updater.cpp
@@ -23,11 +23,10 @@ AS5600Updater::AS5600Updater(QSharedPointer<VehicleState> vehicleState, double a
          if (res == 0) {
             //qDebug() << "as5600: scaled angle: " << scaled_angle << "| in Radians : "  <<"| in degrees: " << deg ;
             angleInDegrees = angleInDegrees - this->angleOffset;
-            double angleRadians = angleInDegrees * (M_PI / 180.0);
             // for the moment only a truck has an angle sensor
             QSharedPointer<TruckState> truckState = qSharedPointerDynamicCast<TruckState>(vehicleState);
             if (truckState) {
-                  truckState->setTrailerAngle(scaled_angle, angleRadians, angleInDegrees);
+                  truckState->setTrailerAngle(angleInDegrees);
             } else {
                qDebug() << "Error: Failed to cast VehicleState to TruckState.";
             }

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -17,6 +17,14 @@ TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : VehicleState 
 
 }
 
+void TrailerState::updateOdomPositionAndYaw(double drivenDistance, PosType usePosType)
+{
+    // In our context, the trailer is passive.
+    // Its position / state is updated by the truck / towing vehicle it is attached to
+    Q_UNUSED(drivenDistance)
+    Q_UNUSED(usePosType)
+}
+
 #ifdef QT_GUI_LIB
 // draw on demand
 void TrailerState::drawTrailer(QPainter &painter, const QTransform &drawTrans, const PosPoint &carPos, double angle)

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -7,7 +7,7 @@
 #include "trailerstate.h"
 #include <QDebug>
 
-TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : ObjectState (id, color)
+TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : VehicleState (id, color)
 {
 
     mLength = 0.96; // griffin specific

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -31,8 +31,8 @@ public:
     void setWheelBase(double value){ mWheelBase = value;}
 
     // VehicleState interface
+    void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType);
     // TODO
-    void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType) { Q_UNUSED(drivenDistance); Q_UNUSED(usePosType); };
     double steeringCurvatureToSteering(double steeringCurvature) { Q_UNUSED(steeringCurvature); return 0;};
 
 #ifdef QT_GUI_LIB

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -10,13 +10,13 @@
 
 
 #include <QObject>
-#include "vehicles/objectstate.h"
+#include "vehicles/vehiclestate.h"
 
 #ifdef QT_GUI_LIB
 #include <QPainter>
 #endif
 
-class TrailerState : public ObjectState
+class TrailerState : public VehicleState
 {
     Q_OBJECT
 public:
@@ -29,6 +29,11 @@ public:
     void setWidth(double width) { mWidth = width; }
     double getWheelBase() const{ return mWheelBase;}
     void setWheelBase(double value){ mWheelBase = value;}
+
+    // VehicleState interface
+    // TODO
+    void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType) { Q_UNUSED(drivenDistance); Q_UNUSED(usePosType); };
+    double steeringCurvatureToSteering(double steeringCurvature) { Q_UNUSED(steeringCurvature); return 0;};
 
 #ifdef QT_GUI_LIB
     // drawing functions for trailer (to draw a trailer)

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -77,11 +77,9 @@ void TruckState::setTrailerState(QSharedPointer<TrailerState> newTrailerState)
     mHasTrailer = true;
 }
 
-void TruckState::setTrailerAngle(uint16_t raw_angle , double angle_in_radians, double agnle_in_degrees)
+void TruckState::setTrailerAngle(double angle_deg)
 {
-    mTrailerRawAngle = raw_angle;
-    mTrailerAngleRadians = angle_in_radians;
-    mTrailerAngleDegress = agnle_in_degrees;
+    mTrailerAngle_deg = angle_deg;
 }
 
 

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -17,7 +17,7 @@ TruckState::TruckState(ObjectID_t id, Qt::GlobalColor color) : CarState(id, colo
 
 double TruckState::getCurvatureToPointInVehicleFrame(const QPointF &point)
 {
-    if (hasTrailer())
+    if (hasTrailingVehicle())
         return getCurvatureWithTrailer(point);
     else {
         // just Call the base class
@@ -48,21 +48,6 @@ double TruckState::getCurvatureWithTrailer(const QPointF &pointInVehicleFrame)
         double curve = gain *( measuredTrailerAngle - desired_hitch_angle ) - ( sin(measuredTrailerAngle)/ (l2));
         return curve/cos(measuredTrailerAngle);
     }
-}
-
-bool TruckState::hasTrailer() const
-{
-    return !mTrailerState.isNull();
-}
-
-QSharedPointer<TrailerState> TruckState::getTrailerState() const
-{
-    return mTrailerState;
-}
-
-void TruckState::setTrailerState(QSharedPointer<TrailerState> newTrailerState)
-{
-    mTrailerState = newTrailerState;
 }
 
 void TruckState::setTrailerAngle(double angle_deg)

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -15,15 +15,9 @@ TruckState::TruckState(ObjectID_t id, Qt::GlobalColor color) : CarState(id, colo
     ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_TRUCK);
 }
 
-void TruckState::updateOdomPositionAndYaw(double drivenDistance, PosType usePosType)
-{
-    // just Call the base class
-    CarState::updateOdomPositionAndYaw(drivenDistance, usePosType);
-}
-
 double TruckState::getCurvatureToPointInVehicleFrame(const QPointF &point)
 {
-    if (mHasTrailer)
+    if (hasTrailer())
         return getCurvatureWithTrailer(point);
     else {
         // just Call the base class
@@ -36,7 +30,7 @@ double TruckState::getCurvatureWithTrailer(const QPointF &pointInVehicleFrame)
     double measuredTrailerAngle = getTrailerAngleRadians() ;
     double l2 = mTrailerState->getWheelBase(); // trailer wheelbase in meters
 
-    if (getSpeed()> 0 ){
+    if (getSpeed() > 0){
         double theta_err =  atan2(pointInVehicleFrame.y(), pointInVehicleFrame.x());
         double desired_hitch_angle = atan(2*l2*sin(theta_err)); // desired trailer/hitch angle
         double gain = getPurePursuitForwardGain();
@@ -56,14 +50,9 @@ double TruckState::getCurvatureWithTrailer(const QPointF &pointInVehicleFrame)
     }
 }
 
-bool TruckState::getHasTrailer() const
+bool TruckState::hasTrailer() const
 {
-    return mHasTrailer;
-}
-
-void TruckState::setHasTrailer(bool hasTrailer)
-{
-    mHasTrailer = hasTrailer;
+    return !mTrailerState.isNull();
 }
 
 QSharedPointer<TrailerState> TruckState::getTrailerState() const
@@ -74,7 +63,6 @@ QSharedPointer<TrailerState> TruckState::getTrailerState() const
 void TruckState::setTrailerState(QSharedPointer<TrailerState> newTrailerState)
 {
     mTrailerState = newTrailerState;
-    mHasTrailer = true;
 }
 
 void TruckState::setTrailerAngle(double angle_deg)
@@ -136,11 +124,8 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     painter.setBrush(col_hull);
     painter.drawRoundedRect(-truck_len / 6.0, -((truck_w - truck_len / 20.0) / 2.0), truck_len - (truck_len / 20.0), truck_w - truck_len / 20.0, truck_corner, truck_corner);
 
-    // draw trailer if exist
-    if (!mTrailerState.isNull()) {
-        double angleInDegrees = getTrailerAngleDegrees();
-        mTrailerState->drawTrailer(painter,drawTrans, pos, angleInDegrees);
-    }
+    if (hasTrailer())
+        mTrailerState->drawTrailer(painter, drawTrans, pos, getTrailerAngleDegrees());
 
     painter.restore();
 

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -32,6 +32,14 @@ void TruckState::updateOdomPositionAndYaw(double drivenDistance, PosType usePosT
         updateTrailingVehicleOdomPositionAndYaw(getPosition(usePosType), usePosType);
 }
 
+void TruckState::setPosition(PosPoint &point)
+{
+    CarState::setPosition(point);
+    if (hasTrailingVehicle()){
+        updateTrailingVehicleOdomPositionAndYaw(point, point.getType());
+    }
+}
+
 void TruckState::updateTrailingVehicleOdomPositionAndYaw(PosPoint hitchPosition, PosType usePosType)
 {
     if(hasTrailingVehicle()) {

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -149,8 +149,8 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     painter.setBrush(col_hull);
     painter.drawRoundedRect(-truck_len / 6.0, -((truck_w - truck_len / 20.0) / 2.0), truck_len - (truck_len / 20.0), truck_w - truck_len / 20.0, truck_corner, truck_corner);
 
-    if (hasTrailer())
-        mTrailerState->drawTrailer(painter, drawTrans, pos, getTrailerAngleDegrees());
+    if (hasTrailingVehicle())
+        getTrailingVehicle()->drawTrailer(painter, drawTrans, pos, getTrailerAngleDegrees());
 
     painter.restore();
 
@@ -167,7 +167,7 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     double trailerAngle  = getTrailerAngleRadians();
     double currYaw_rad = getPosition().getYaw() * (M_PI/180.0);
     double trailerYaw = currYaw_rad- trailerAngle;
-    double trailerAxis = getTrailerWheelBase();
+    double trailerAxis = getTrailingVehicle()->getWheelBase();
     double dx = trailerAxis * cos(trailerYaw);
     double dy = trailerAxis * sin(trailerYaw);
     double newX = (pos.getX() - dx) *1000.0;
@@ -180,11 +180,6 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
     painter.setBrush(Qt::transparent);
     painter.drawEllipse(QPointF(newX, newY), getAutopilotRadius()*1000.0, getAutopilotRadius()*1000.0);
     painter.setPen(Qt::black);
-
-
-    QString txt;
-    QPointF pt_txt;
-    QRectF rect_txt;
 
     if (getDrawStatusText()) {
         // Print data
@@ -217,8 +212,8 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
                   << "(" << pos.getX() << ", " << pos.getY() << ", " << pos.getHeight() << ", " << pos.getYaw() << ")" << Qt::endl
                   << "State: " << (getIsArmed() ? "armed" : "disarmed") << Qt::endl
                   << flightModeStr << Qt::endl << Qt::endl;
-        if (!mTrailerState.isNull()) {
-            txtStream << mTrailerState->getName() << Qt::endl
+        if (hasTrailingVehicle()) {
+            txtStream << getTrailingVehicle()->getName() << Qt::endl
                     << "(" << pos.getX()- dx << ", " << pos.getY()- dy << ", " << pos.getHeight() << ", "
                     << trailerYaw * (180.0/M_PI)<< ")" << Qt::endl;
         }

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -7,8 +7,8 @@
 #ifndef TRUCKSTATE_H
 #define TRUCKSTATE_H
 
-#include "carstate.h"
-#include "trailerstate.h"
+#include "vehicles/carstate.h"
+#include "vehicles/trailerstate.h"
 #include <QSharedPointer>
 
 class TruckState : public CarState
@@ -17,13 +17,9 @@ class TruckState : public CarState
 public:
     TruckState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::blue);
 
-    // Additional set/get state for angle sensor
-    double getTrailerAngleRadians() const { return mTrailerAngle_deg * (M_PI / 180.0); }
-    double getTrailerAngleDegrees() const { return mTrailerAngle_deg; }
-
-    void setTrailerAngle(double angle_deg);
-
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
+    virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
+    void updateTrailingVehicleOdomPositionAndYaw(PosPoint hitchPosition, PosType usePosType = PosType::odom);
 
     double getPurePursuitForwardGain() const{ return mPurePursuitForwardGain;}
     void setPurePursuitForwardGain(double value){ mPurePursuitForwardGain = value;}
@@ -31,19 +27,26 @@ public:
     double getPurePursuitReverseGain() const{ return mPurePursuitReverseGain;}
     void setPurePursuitReverseGain(double value){ mPurePursuitReverseGain = value;}
 
+    QSharedPointer<TrailerState> getTrailingVehicle() const;
+    void setTrailingVehicle(QSharedPointer<TrailerState> trailer);
+    // Additional set/get state for angle of trailing vehicle towards us / ego vehicle
+    double getTrailerAngleRadians() const { return mTrailerAngle_deg * (M_PI / 180.0); }
+    double getTrailerAngleDegrees() const { return mTrailerAngle_deg; }
+    void setTrailerAngle(double angle_deg);
+
 #ifdef QT_GUI_LIB
     // Override or add drawing functions if needed (to draw a truck)
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) override;
 #endif
 
 private:
-    double mTrailerAngle_deg; // Angle in Degrees
-    QSharedPointer<TrailerState> mTrailerState = nullptr; // trailer created dynamically
-
     double mPurePursuitForwardGain;
     double mPurePursuitReverseGain;
 
+    double mTrailerAngle_deg; // Angle in Degrees
+
     double getCurvatureWithTrailer(const QPointF &point);
+
 };
 
 #endif // TRUCKSTATE_H

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -23,16 +23,12 @@ public:
 
     void setTrailerAngle(double angle_deg);
 
-    // Override the updateOdomPositionAndYaw function to consider the angle of the trailer
-    virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
-
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
 
     QSharedPointer<TrailerState> getTrailerState() const;
     void setTrailerState(QSharedPointer<TrailerState> newTrailerState);
 
-    bool getHasTrailer() const ;
-    void setHasTrailer(bool mHasTrailer);
+    bool hasTrailer() const;
 
     double getPurePursuitForwardGain() const{ return mPurePursuitForwardGain;}
     void setPurePursuitForwardGain(double value){ mPurePursuitForwardGain = value;}
@@ -47,8 +43,7 @@ public:
 
 private:
     double mTrailerAngle_deg; // Angle in Degrees
-    QSharedPointer<TrailerState> mTrailerState; // trailer created dynamically
-    bool mHasTrailer = false;
+    QSharedPointer<TrailerState> mTrailerState = nullptr; // trailer created dynamically
 
     double mPurePursuitForwardGain;
     double mPurePursuitReverseGain;

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -18,14 +18,10 @@ public:
     TruckState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::blue);
 
     // Additional set/get state for angle sensor
-    uint16_t getTrailerAngleRaw() const { return mTrailerRawAngle; }
-    double getTrailerAngleRadians() const { return mTrailerAngleRadians; }
-    double getTrailerAngleDegrees() const { return mTrailerAngleDegress; }
-    double getTrailerWheelBase() const { return mtrailerwheelbase; }
-    void setTrailerWheelBase ( double value ){ mtrailerwheelbase =value;}
+    double getTrailerAngleRadians() const { return mTrailerAngle_deg * (M_PI / 180.0); }
+    double getTrailerAngleDegrees() const { return mTrailerAngle_deg; }
 
-
-    void setTrailerAngle(uint16_t raw_angle , double angle_in_radians, double agnle_in_degrees);
+    void setTrailerAngle(double angle_deg);
 
     // Override the updateOdomPositionAndYaw function to consider the angle of the trailer
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
@@ -50,10 +46,7 @@ public:
 #endif
 
 private:
-    uint16_t mTrailerRawAngle; // Raw angle value from sensor
-    double mTrailerAngleRadians; // Angle in Radians
-    double mTrailerAngleDegress; // Angle in Degrees
-    double mtrailerwheelbase; // trailer wheelbase
+    double mTrailerAngle_deg; // Angle in Degrees
     QSharedPointer<TrailerState> mTrailerState; // trailer created dynamically
     bool mHasTrailer = false;
 

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -33,6 +33,7 @@ public:
     double getTrailerAngleRadians() const { return mTrailerAngle_deg * (M_PI / 180.0); }
     double getTrailerAngleDegrees() const { return mTrailerAngle_deg; }
     void setTrailerAngle(double angle_deg);
+    virtual void setPosition(PosPoint &point) override;
 
 #ifdef QT_GUI_LIB
     // Override or add drawing functions if needed (to draw a truck)

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -25,11 +25,6 @@ public:
 
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
 
-    QSharedPointer<TrailerState> getTrailerState() const;
-    void setTrailerState(QSharedPointer<TrailerState> newTrailerState);
-
-    bool hasTrailer() const;
-
     double getPurePursuitForwardGain() const{ return mPurePursuitForwardGain;}
     void setPurePursuitForwardGain(double value){ mPurePursuitForwardGain = value;}
 

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -22,6 +22,8 @@ public:
     double getTrailerAngleRadians() const { return mTrailerAngleRadians; }
     double getTrailerAngleDegrees() const { return mTrailerAngleDegress; }
     double getTrailerWheelBase() const { return mtrailerwheelbase; }
+    void setTrailerWheelBase ( double value ){ mtrailerwheelbase =value;}
+
 
     void setTrailerAngle(uint16_t raw_angle , double angle_in_radians, double agnle_in_degrees);
 

--- a/vehicles/vehiclestate.cpp
+++ b/vehicles/vehiclestate.cpp
@@ -135,3 +135,18 @@ double VehicleState::getCurvatureToPointInENU(const QPointF &point, PosType type
 
     return getCurvatureToPointInVehicleFrame(coordinateTransforms::ENUToVehicleFrame(point, vehiclePosition.getXYZ(), vehiclePosition.getYaw()));
 }
+
+QSharedPointer<VehicleState> VehicleState::getTrailingVehicle() const
+{
+    return mTrailingVehicle;
+}
+
+void VehicleState::setTrailingVehicle(QSharedPointer<VehicleState> trailer)
+{
+    mTrailingVehicle = trailer;
+}
+
+bool VehicleState::hasTrailingVehicle() const
+{
+    return !mTrailingVehicle.isNull();
+}

--- a/vehicles/vehiclestate.h
+++ b/vehicles/vehiclestate.h
@@ -14,6 +14,7 @@
 #include <QObject>
 #include <QVector>
 #include <QString>
+#include <QSharedPointer>
 #ifdef QT_GUI_LIB
 #include <QPainter>
 #endif
@@ -76,6 +77,12 @@ public:
     virtual double getCurvatureToPointInVehicleFrame(const QPointF &point);
     double getCurvatureToPointInENU(const QPointF &point, PosType type);
 
+    // A vehicle can have a trailing vehicle
+    // what this means needs to be defined in child classes
+    QSharedPointer<VehicleState> getTrailingVehicle() const;
+    void setTrailingVehicle(QSharedPointer<VehicleState> trailer);
+    bool hasTrailingVehicle() const;
+
     void simulationStep(double dt_ms, PosType usePosType = PosType::simulated); // Take current state and simulate step forward for dt_ms milliseconds, update state accordingly
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) = 0;
     virtual double steeringCurvatureToSteering(double steeringCurvature) = 0;
@@ -104,6 +111,8 @@ private:
     bool mIsArmed = false;
     FlightMode mFlightMode = FlightMode::Unknown;
     double mAutopilotRadius = 0;
+
+    QSharedPointer<VehicleState> mTrailingVehicle;
 
     std::array<float,3> mGyroscopeXYZ = std::array<float,3>({0.0, 0.0, 0.0}); // [deg/s]
     std::array<float,3> mAccelerometerXYZ = std::array<float,3>({0.0, 0.0, 0.0}); // [g]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
PurepursuitWaypointFollower takes the trailer location for route following when a trailer is present and the truck is going backwards. In order to implement this, TruckState and TrailerState have been refactored:
- TrailerState is a vehicleState, TruckState::updateOdomPositionAndYaw updates its position and yaw.
- VehicleState implements the concept of trailing VehicleStates (all VehicleStates can have and be trailers), the behavior needs to be implemented in descending classes (like TruckState). This is to not drag TruckState / TrailerState in as a dependence where a trailer is handles (like PurepursuitWaypointFollower)

* **What is the current behavior?** (You can also link to an open issue here)
PurepursuitWaypointFollower takes the truck's position when following a route going backwards.


* **What is the new behavior (if this is a feature change)?**
PurepursuitWaypointFollower takes the trailer location for route following when a trailer is present and the truck is going backwards.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, interfaces of TruckState and TrailerState have changed. Outside of this, no changes.


* **Other information**:


