### PR TITLE
Instantiate MAVLINK Component for trailer in MavsdkVehicleServer

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -784,7 +784,7 @@ void MavsdkVehicleServer::createMavsdkComponentForTrailer(const QHostAddress con
                             0.0,            // time_boot_ms (not used)
                             0.0,            // roll (not used)
                             0.0,            // pitch (not used)
-                            trailerState->getPosition(PosType::fused).getYaw() * (M_PI / 180.0),   // yaw (your desired yaw value)
+                            trailerState->getPosition(PosType::fused).getYaw() * (M_PI / 180.0),   // yaw
                             0.0,            // rollspeed (not used)
                             0.0,            // pitchspeed (not used)
                             0.0             // yawspeed (not used)

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -435,8 +435,11 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         break;
     }
 
-    if (result == mavsdk::ConnectionResult::Success)
+    if (result == mavsdk::ConnectionResult::Success) {
         qDebug() << "MavsdkVehicleServer is listening on" << controlTowerAddress.toString() << "with port" << controlTowerPort;
+        if (vehicleState->hasTrailingVehicle())
+            createMavsdkComponentForTrailer(controlTowerAddress, controlTowerPort, controlTowerSocketType);
+    }
 
     ParameterServer::getInstance()->provideFloatParameter("MC_MAX_SPEED_MS", std::bind(&MavsdkVehicleServer::setManualControlMaxSpeed, this, std::placeholders::_1), std::bind(&MavsdkVehicleServer::getManualControlMaxSpeed, this));
     ParameterServer::getInstance()->provideIntParameter("VEH_WW_OBJ_TYPE",
@@ -701,5 +704,66 @@ void MavsdkVehicleServer::sendMissionAck(quint8 type)
         return mavMissionAckMsg;
     }) != mavsdk::MavlinkPassthrough::Result::Success)
             qWarning() << "Could not send MISSION_ACK via MAVLINK.";
+}
+
+void MavsdkVehicleServer::createMavsdkComponentForTrailer(const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType)
+{
+    auto mTrailerState = mVehicleState->getTrailingVehicle();
+
+    mavsdk::Mavsdk::Configuration config =
+        mavsdk::Mavsdk::Configuration{mavsdk::Mavsdk::ComponentType::Custom};
+    config.set_system_id(mVehicleState->getId());
+    config.set_always_send_heartbeats(true);
+    config.set_component_id(mTrailerState->getId());
+    mTrailerMavsdk.reset(new mavsdk::Mavsdk{config});
+
+    mTrailerMavsdk->subscribe_on_new_system(
+        [this]() {
+            for (const auto & system : mTrailerMavsdk->systems()) {
+                auto mavlinkPassthrough = new mavsdk::MavlinkPassthrough(system);
+                mavlinkPassthrough->subscribe_message(
+                    MAVLINK_MSG_ID_HEARTBEAT,
+                    [this, mavlinkPassthrough, system](const mavlink_message_t & message) {
+                        mavlink_heartbeat_t heartbeat;
+                        mavlink_msg_heartbeat_decode(&message, &heartbeat);
+                        // unsubscribe from further heartbeats by deleting passthrough
+                        delete mavlinkPassthrough;
+                        if ((MAV_TYPE) heartbeat.type == MAV_TYPE_GCS)
+                            mTrailerMavlinkPassthrough.reset(new mavsdk::MavlinkPassthrough(system));
+                    });
+            }
+        });
+
+    mTrailerMavsdk->intercept_outgoing_messages_async(
+        [mTrailerState](mavlink_message_t & message) {
+            switch (message.msgid) {
+            case MAVLINK_MSG_ID_HEARTBEAT: // Fix some info in heartbeat s.th. MAVSDK / ControlTower detects vehicle correctly
+                mavlink_heartbeat_t heartbeat;
+                mavlink_msg_heartbeat_decode(&message, &heartbeat);
+                if (message.compid == mTrailerState->getId()) {
+                    heartbeat.type = MAV_TYPE_ONBOARD_CONTROLLER;
+                    heartbeat.autopilot = MAV_AUTOPILOT_INVALID;
+                }
+                mavlink_msg_heartbeat_encode(message.sysid, message.compid, &message, &heartbeat);
+                break;
+            default:;
+                //            qDebug() << "out:" << message.msgid;
+            }
+            return true;
+        });
+
+    mavsdk::ConnectionResult result;
+    switch (controlTowerSocketType) {
+    case QAbstractSocket::UdpSocket:
+        result = mTrailerMavsdk->setup_udp_remote(controlTowerAddress.toString().toStdString(), controlTowerPort);
+        break;
+    default:
+        qDebug() << "MavsdkVehicleServer initialized for unsupported controlTowerSocketType. Not connecting.";
+        result = mavsdk::ConnectionResult::SocketError;
+        break;
+    }
+
+    if (result == mavsdk::ConnectionResult::Success)
+        qDebug() << "Trailer component listening for MAVSDK connection.";
 }
 

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -47,6 +47,8 @@ private:
     std::shared_ptr<mavsdk::MissionRawServer> mMissionRawServer;
     std::shared_ptr<mavsdk::MavlinkPassthrough> mMavlinkPassthrough;
     QTimer mPublishMavlinkTimer;
+    std::shared_ptr<mavsdk::Mavsdk> mTrailerMavsdk;
+    std::shared_ptr<mavsdk::MavlinkPassthrough> mTrailerMavlinkPassthrough;
 
     QDateTime mMavsdkVehicleServerCreationTime = QDateTime::currentDateTime();
     ParameterServer *mParameterServer;
@@ -61,6 +63,7 @@ private:
     void sendMissionAck(quint8 type);
     double mManualControlMaxSpeed = 2.0; // [m/s]
     quint8 mSystemId = 1;
+    void createMavsdkComponentForTrailer(const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType);
 };
 
 #endif // MAVSDKVEHICLESERVER_H

--- a/userinterface/flyui.ui
+++ b/userinterface/flyui.ui
@@ -53,7 +53,7 @@
      <property name="title">
       <string>Advanced</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
        <widget class="QPushButton" name="pollENUrefButton">
         <property name="text">

--- a/vehicles/objectstate.h
+++ b/vehicles/objectstate.h
@@ -38,6 +38,7 @@ public:
     typedef xyz_t Velocity;
     typedef xyz_t Acceleration;
     ObjectState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::red);
+    virtual void provideParameters() {}; // Provide using ParameterServer in child classes (if implemented)
 #ifdef QT_GUI_LIB
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
     virtual QPainterPath getBoundingBox() const { return QPainterPath(); }

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "trailerstate.h"
+#include "communication/parameterserver.h"
 #include <QDebug>
 
 TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : VehicleState (id, color)
@@ -15,6 +16,14 @@ TrailerState::TrailerState(ObjectID_t id, Qt::GlobalColor color) : VehicleState 
 
     ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_TRAILER);
 
+}
+
+void TrailerState::provideParameters()
+{
+    ParameterServer::getInstance()->provideIntParameter("TRLR_COMP_ID", std::bind(&TrailerState::setId, this, std::placeholders::_1, false), std::bind(&TrailerState::getId, this));
+    ParameterServer::getInstance()->provideFloatParameter("TRLR_LENGTH", std::bind(&TrailerState::setLength, this, std::placeholders::_1), std::bind(&TrailerState::getLength, this));
+    ParameterServer::getInstance()->provideFloatParameter("TRLR_WIDTH", std::bind(&TrailerState::setWidth, this, std::placeholders::_1), std::bind(&TrailerState::getWidth, this));
+    ParameterServer::getInstance()->provideFloatParameter("TRLR_WHLBASE", std::bind(&TrailerState::setWheelBase, this, std::placeholders::_1), std::bind(&TrailerState::getWheelBase, this));
 }
 
 void TrailerState::updateOdomPositionAndYaw(double drivenDistance, PosType usePosType)

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -22,6 +22,7 @@ class TrailerState : public VehicleState
 public:
 
     TrailerState(ObjectID_t id = 25, Qt::GlobalColor color = Qt::white);
+    virtual void provideParameters() override;
 
     double getLength() const { return mLength; }
     void setLength(double length) { mLength = length; }

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -171,23 +171,27 @@ void TruckState::draw(QPainter &painter, const QTransform &drawTrans, const QTra
 
     painter.drawEllipse(QPointF(x, y), getAutopilotRadius()*1000.0, getAutopilotRadius()*1000.0);
     painter.setPen(Qt::black);
+    // Turning radius
 
-    double trailerAngle  = getTrailerAngleRadians();
-    double currYaw_rad = getPosition().getYaw() * (M_PI/180.0);
-    double trailerYaw = currYaw_rad- trailerAngle;
-    double trailerAxis = getTrailingVehicle()->getWheelBase();
-    double dx = trailerAxis * cos(trailerYaw);
-    double dy = trailerAxis * sin(trailerYaw);
-    double newX = (pos.getX() - dx) *1000.0;
-    double newY = ( pos.getY() - dy) *1000.0;
+    // TODO: needs cleanup
+    double trailerYaw = 0.0, dx = 0.0, dy = 0.0;
+    if (hasTrailingVehicle()) {
+        double trailerAngle  = getTrailerAngleRadians();
+        double currYaw_rad = getPosition().getYaw() * (M_PI/180.0);
+        double trailerYaw = currYaw_rad- trailerAngle;
+        double trailerAxis = getTrailingVehicle()->getWheelBase();
+        double dx = trailerAxis * cos(trailerYaw);
+        double dy = trailerAxis * sin(trailerYaw);
+        double newX = (pos.getX() - dx) *1000.0;
+        double newY = ( pos.getY() - dy) *1000.0;
 
-    painter.setBrush(Qt::darkMagenta);
-    painter.drawEllipse(QPointF(newX, newY), truck_w / 15.0, truck_w / 15.0);
-     // Turning radius
-    painter.setPen(QPen(Qt::darkMagenta, 20));
-    painter.setBrush(Qt::transparent);
-    painter.drawEllipse(QPointF(newX, newY), getAutopilotRadius()*1000.0, getAutopilotRadius()*1000.0);
-    painter.setPen(Qt::black);
+        painter.setBrush(Qt::darkMagenta);
+        painter.drawEllipse(QPointF(newX, newY), truck_w / 15.0, truck_w / 15.0);
+        painter.setPen(QPen(Qt::darkMagenta, 20));
+        painter.setBrush(Qt::transparent);
+        painter.drawEllipse(QPointF(newX, newY), getAutopilotRadius()*1000.0, getAutopilotRadius()*1000.0);
+        painter.setPen(Qt::black);
+    }
 
     if (getDrawStatusText()) {
         // Print data

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "truckstate.h"
+#include "communication/parameterserver.h"
 #include <QDebug>
 #include <QDateTime>
 
@@ -13,6 +14,13 @@ TruckState::TruckState(ObjectID_t id, Qt::GlobalColor color) : CarState(id, colo
 {
     // Additional initialization if needed for the TruckState
     ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_TRUCK);
+}
+
+void TruckState::provideParameters()
+{
+    ParameterServer::getInstance()->provideFloatParameter("VEH_LENGTH", std::bind(&TruckState::setLength, this, std::placeholders::_1), std::bind(&TruckState::getLength, this));
+    ParameterServer::getInstance()->provideFloatParameter("VEH_WIDTH", std::bind(&TruckState::setWidth, this, std::placeholders::_1), std::bind(&TruckState::getWidth, this));
+    ParameterServer::getInstance()->provideFloatParameter("VEH_WHLBASE", std::bind(&TruckState::setAxisDistance, this, std::placeholders::_1), std::bind(&TruckState::getAxisDistance, this));
 }
 
 double TruckState::getCurvatureToPointInVehicleFrame(const QPointF &point)

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -16,6 +16,7 @@ class TruckState : public CarState
     Q_OBJECT
 public:
     TruckState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::blue);
+    virtual void provideParameters() override;
 
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In short, this PR moves the MAVLINK specifics implemented in RISE-Dependable-Transport-Systems/WayWiseR@7716c8f from waywiser_node to MavsdkVehicleServer.


* **What is the current behavior?** (You can also link to an open issue here)
WayWiseR provides an implementation of truck and trailer (mavlink component, parameters) that is only supported by the desktop / ControlTower side of WayWise. The implementation vehicle-side implementation should actually be in WayWise to make it available to all WayWise-based vehicles.


* **What is the new behavior (if this is a feature change)?**
The respective code is moved to WayWise, making the code in waywiser_node redundant.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, the respective code needs to be removed from waywiser_node.


* **Other information**:
I did not test with WayWiseR, only WayWise and would appreciate help with testing and comments whether how this turned out works for WayWiseR. 😊

See also RISE-Dependable-Transport-Systems/Griffin-RC-Semi-Truck@7d1b5bc

