### PR TITLE
TruckState: add simple trailer simulation, revise updateTrailingVehicleOdomPositionAndYaw

### DIFF
--- a/sensors/angle/anglesensorupdater.h
+++ b/sensors/angle/anglesensorupdater.h
@@ -19,6 +19,7 @@ public:
     AngleSensorUpdater(QSharedPointer<VehicleState> vehicleState);
     QSharedPointer<VehicleState> getVehicleState() const;
     virtual bool setUpdateIntervall(int intervall_ms) = 0;
+    virtual bool isConnected() = 0;
 
 
 signals:

--- a/sensors/angle/as5600updater.cpp
+++ b/sensors/angle/as5600updater.cpp
@@ -26,15 +26,16 @@ AS5600Updater::AS5600Updater(QSharedPointer<VehicleState> vehicleState, double a
             // for the moment only a truck has an angle sensor
             QSharedPointer<TruckState> truckState = qSharedPointerDynamicCast<TruckState>(vehicleState);
             if (truckState) {
-                  truckState->setTrailerAngle(angleInDegrees);
+                truckState->setTrailerAngle(angleInDegrees);
+                mIsConnected = true;
             } else {
-               qDebug() << "Error: Failed to cast VehicleState to TruckState.";
+                qDebug() << "Error: Failed to cast VehicleState to TruckState.";
             }
          } else {
             qDebug() << "ERROR: as5600 Read failed";
          }
-      });   
-      mPollTimer.start(mPollIntervall_ms); // call back (poll) every mPollIntervall_ms e.g., 50 ms
+      });
+      mPollTimer.start(mPollIntervall_ms);
    } else {
       qDebug() << "ERROR: Unable to open i2c bus to AS5600";
    }
@@ -46,6 +47,11 @@ bool AS5600Updater::setUpdateIntervall(int pollIntervall_ms)
    mPollTimer.start(mPollIntervall_ms);
 
    return true;
+}
+
+bool AS5600Updater::isConnected()
+{
+    return mIsConnected;
 }
 
 void AS5600Updater::printSensorInfo()

--- a/sensors/angle/as5600updater.h
+++ b/sensors/angle/as5600updater.h
@@ -23,11 +23,14 @@ public:
     AS5600Updater(QSharedPointer<VehicleState> vehicleState, double angleOffset=0);
     void printSensorInfo();
     virtual bool setUpdateIntervall(int pollIntervall_ms) override;
+    virtual bool isConnected() override;
 
 private:
     int mPollIntervall_ms = 50; // interval (ms) to read from AS5600,
     QTimer mPollTimer;
+    bool mIsConnected = false;
     double angleOffset; // offset if the start angle is not zero
+
 };
 
 #endif // AS5600UPDATER_H

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -44,9 +44,10 @@ public:
     double mAngle;
 
 private:
-    double mLength; // [m]
-    double mWidth; // [m]
-    double mWheelBase; //[m]
+    // Default values from Griffin
+    double mLength = 0.96; // [m]
+    double mWidth = 0.21; // [m]
+    double mWheelBase = 0.64; //[m]
 };
 
 #endif // TRAILERSTATE_H

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -20,7 +20,7 @@ public:
 
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
-    void updateTrailingVehicleOdomPositionAndYaw(PosPoint hitchPosition, PosType usePosType = PosType::odom);
+    void updateTrailingVehicleOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom);
 
     double getPurePursuitForwardGain() const{ return mPurePursuitForwardGain;}
     void setPurePursuitForwardGain(double value){ mPurePursuitForwardGain = value;}
@@ -36,16 +36,20 @@ public:
     void setTrailerAngle(double angle_deg);
     virtual void setPosition(PosPoint &point) override;
 
+    bool getSimulateTrailer() const;
+    void setSimulateTrailer(bool simulateTrailer);
+
 #ifdef QT_GUI_LIB
     // Override or add drawing functions if needed (to draw a truck)
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) override;
 #endif
 
 private:
-    double mPurePursuitForwardGain;
-    double mPurePursuitReverseGain;
+    double mPurePursuitForwardGain = 1.0;
+    double mPurePursuitReverseGain = -1.0;
 
-    double mTrailerAngle_deg; // Angle in Degrees
+    double mTrailerAngle_deg = 0.0;
+    bool mSimulateTrailer = false;
 
     double getCurvatureWithTrailer(const QPointF &point);
 

--- a/vehicles/vehiclelighting.cpp
+++ b/vehicles/vehiclelighting.cpp
@@ -40,10 +40,14 @@ VehicleLighting::VehicleLighting(QSharedPointer<VehicleState> vehicleState, QStr
 VehicleLighting::~VehicleLighting()
 {
     // Release lines
-    mBackupLight.release();
-    mBrakeLight.release();
-    mRightTurnSignal.release();
-    mLeftTurnSignal.release();
+    if (mBackupLight)
+        mBackupLight.release();
+    if (mBrakeLight)
+        mBrakeLight.release();
+    if (mRightTurnSignal)
+        mRightTurnSignal.release();
+    if (mLeftTurnSignal)
+        mLeftTurnSignal.release();
 }
 
 void VehicleLighting::turnSignal(double steering)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
TruckState gets the possibility to simulate trailer movements when no external updates (e.g., angel sensor) are received.

* **What is the current behavior?** (You can also link to an open issue here)
When running WayWise-based simulation, the trailer is fixed at a 0 degree angle towards the vehicle.


* **What is the new behavior (if this is a feature change)?**
TruckState::setSimulateTrailer(..) allows to enable a very simple simulation of trailer movements.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
As part of this PR, updateTrailingVehicleOdomPositionAndYaw was revised and its interface changed to (drivenDistance, usePosType) (from point, usePosType).


* **Other information**:
![0005](https://github.com/user-attachments/assets/66931b96-f235-470b-8e2c-e41b9e892817)

