### PR TITLE
Minor fixes concerning parameters, fixes #72

### DIFF
--- a/communication/vehicleconnections/mavsdkvehicleconnection.cpp
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.cpp
@@ -885,19 +885,16 @@ ParameterServer::AllParameters MavsdkVehicleConnection::getAllParametersFromVehi
     for (const auto& vehicleParameter : mavsdkVehicleParameters.int_params) {
         intParameter.name = vehicleParameter.name;
         intParameter.value = vehicleParameter.value;
-        intParameter.value = mParam->get_param_int(intParameter.name).second; //Remove this line when issue #72 is closed
         allParameters.intParameters.push_back(intParameter);
     }
     for (const auto& vehicleParameter : mavsdkVehicleParameters.float_params) {
         floatParameter.name = vehicleParameter.name;
         floatParameter.value = vehicleParameter.value;
-        floatParameter.value = mParam->get_param_float(floatParameter.name).second; //Remove this line when issue #72 is closed
         allParameters.floatParameters.push_back(floatParameter);
     }
     for (const auto& vehicleParameter : mavsdkVehicleParameters.custom_params) {
         customParameter.name = vehicleParameter.name;
         customParameter.value = vehicleParameter.value;
-        customParameter.value = mParam->get_param_custom(customParameter.name).second; //Remove this line when issue #72 is closed
         allParameters.customParameters.push_back(customParameter);
     }
 

--- a/vehicles/carstate.cpp
+++ b/vehicles/carstate.cpp
@@ -11,6 +11,8 @@
 #include <QDebug>
 #include <QDateTime>
 
+#include "communication/parameterserver.h"
+
 CarState::CarState(ObjectID_t id, Qt::GlobalColor color) : VehicleState(id, color)
 {
     ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_CAR);
@@ -260,4 +262,11 @@ double CarState::steeringCurvatureToSteering(double steeringCurvature)
         steeringAngle_rad = getMaxSteeringAngle() * ((steeringAngle_rad > 0) ? 1.0 : -1.0);
 
     return steeringAngle_rad / getMaxSteeringAngle();
+}
+
+void CarState::provideParameters()
+{
+    ParameterServer::getInstance()->provideFloatParameter("VEH_LENGTH", std::bind(&CarState::setLength, this, std::placeholders::_1), std::bind(&CarState::getLength, this));
+    ParameterServer::getInstance()->provideFloatParameter("VEH_WIDTH", std::bind(&CarState::setWidth, this, std::placeholders::_1), std::bind(&CarState::getWidth, this));
+    ParameterServer::getInstance()->provideFloatParameter("VEH_WHLBASE", std::bind(&CarState::setAxisDistance, this, std::placeholders::_1), std::bind(&CarState::getAxisDistance, this));
 }

--- a/vehicles/carstate.h
+++ b/vehicles/carstate.h
@@ -30,6 +30,7 @@ public:
 #endif
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;
     virtual double steeringCurvatureToSteering(double steeringCurvature) override;
+    virtual void provideParameters() override;
 
     // Static state
     double getAxisDistance() const { return fabs(mAxisDistance) < 0.001 ? 0.8*getLength() : mAxisDistance; }

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "truckstate.h"
-#include "communication/parameterserver.h"
 #include <QDebug>
 #include <QDateTime>
 
@@ -14,13 +13,6 @@ TruckState::TruckState(ObjectID_t id, Qt::GlobalColor color) : CarState(id, colo
 {
     // Additional initialization if needed for the TruckState
     ObjectState::setWaywiseObjectType(WAYWISE_OBJECT_TYPE_TRUCK);
-}
-
-void TruckState::provideParameters()
-{
-    ParameterServer::getInstance()->provideFloatParameter("VEH_LENGTH", std::bind(&TruckState::setLength, this, std::placeholders::_1), std::bind(&TruckState::getLength, this));
-    ParameterServer::getInstance()->provideFloatParameter("VEH_WIDTH", std::bind(&TruckState::setWidth, this, std::placeholders::_1), std::bind(&TruckState::getWidth, this));
-    ParameterServer::getInstance()->provideFloatParameter("VEH_WHLBASE", std::bind(&TruckState::setAxisDistance, this, std::placeholders::_1), std::bind(&TruckState::getAxisDistance, this));
 }
 
 double TruckState::getCurvatureToPointInVehicleFrame(const QPointF &point)

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -16,7 +16,6 @@ class TruckState : public CarState
     Q_OBJECT
 public:
     TruckState(ObjectID_t id = 1, Qt::GlobalColor color = Qt::blue);
-    virtual void provideParameters() override;
 
     double getCurvatureToPointInVehicleFrame(const QPointF &point) override;
     virtual void updateOdomPositionAndYaw(double drivenDistance, PosType usePosType = PosType::odom) override;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor loose ends after the recent Truck PRs.
- VEH_LENGTH, VEH_WIDTH, VEH_WHLBASE are provided in CarState instead of TruckState (CarState defines these parameters, TruckState inherits)
- A workaround for a MAVSDK bug (that was solved a long time ago) is reverted

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


