### PR TITLE
Base class for gnss receivers

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -510,6 +510,12 @@ void MavsdkVehicleServer::updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) 
 
 }
 
+void MavsdkVehicleServer::setMavsdkRawGpsAndGpsInfo(const mavsdk::TelemetryServer::RawGps &rawGps, const mavsdk::TelemetryServer::GpsInfo &gpsInfo)
+{
+    mRawGps = rawGps;
+    mGpsInfo = gpsInfo;
+}
+
 void MavsdkVehicleServer::setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower)
 {
     mWaypointFollower = waypointFollower;

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -64,14 +64,14 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         mavsdk::TelemetryServer::Position homePositionLlh{};
         mavsdk::TelemetryServer::Position positionLlh{};
 
-        if (!mUbloxRover.isNull()) {
+        if (!mGNSSReceiver.isNull()) {
             // publish gpsOrigin
-            sendGpsOriginLlh(mUbloxRover->getEnuRef());
+            sendGpsOriginLlh(mGNSSReceiver->getEnuRef());
 
             //TODO: homePositionLlh should not be EnuRef
-            homePositionLlh = {mUbloxRover->getEnuRef().latitude, mUbloxRover->getEnuRef().longitude, static_cast<float>(mUbloxRover->getEnuRef().height), 0};
+            homePositionLlh = {mGNSSReceiver->getEnuRef().latitude, mGNSSReceiver->getEnuRef().longitude, static_cast<float>(mGNSSReceiver->getEnuRef().height), 0};
 
-            llh_t fusedPosGlobal = coordinateTransforms::enuToLlh(mUbloxRover->getEnuRef(), {mVehicleState->getPosition(PosType::fused).getXYZ()});
+            llh_t fusedPosGlobal = coordinateTransforms::enuToLlh(mGNSSReceiver->getEnuRef(), {mVehicleState->getPosition(PosType::fused).getXYZ()});
             positionLlh = {fusedPosGlobal.latitude, fusedPosGlobal.longitude, static_cast<float>(fusedPosGlobal.height), 0};
         }
 
@@ -470,11 +470,14 @@ void MavsdkVehicleServer::heartbeatReset()
 
 void MavsdkVehicleServer::setUbloxRover(QSharedPointer<UbloxRover> ubloxRover)
 {
-    if (!mUbloxRover.isNull())
-        disconnect(mUbloxRover.get(), &UbloxRover::txNavPvt, this, &MavsdkVehicleServer::updateRawGpsAndGpsInfoFromUbx);
-
-    mUbloxRover = ubloxRover;
-    connect(mUbloxRover.get(), &UbloxRover::txNavPvt, this, &MavsdkVehicleServer::updateRawGpsAndGpsInfoFromUbx);
+    if (!mGNSSReceiver.isNull()) {
+        QSharedPointer<UbloxRover> mUbloxRover = qSharedPointerDynamicCast<UbloxRover>(mGNSSReceiver);
+        if (mUbloxRover) {
+            disconnect(mUbloxRover.get(), &UbloxRover::txNavPvt, this, &MavsdkVehicleServer::updateRawGpsAndGpsInfoFromUbx);
+        }
+    }
+    VehicleServer::setGNSSReceiver(ubloxRover);
+    connect(ubloxRover.get(), &UbloxRover::txNavPvt, this, &MavsdkVehicleServer::updateRawGpsAndGpsInfoFromUbx);
 }
 
 void MavsdkVehicleServer::updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) {

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -37,6 +37,8 @@ public:
     void sendGpsOriginLlh(const llh_t &gpsOriginLlh) override;
     void mavResult(const uint16_t command, MAV_RESULT result, MAV_COMPONENT compId);
     void on_logSent(const QString& message, const quint8& severity);
+    void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) override;
+    void setMavsdkRawGpsAndGpsInfo(const mavsdk::TelemetryServer::RawGps &rawGps, const mavsdk::TelemetryServer::GpsInfo &gpsInfo);
 
 private:
     std::shared_ptr<mavsdk::Mavsdk> mMavsdk;
@@ -55,7 +57,6 @@ private:
 
     const unsigned mCountdown_ms = 2000;
 
-    void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) override;
     void heartbeatTimeout() override;
     void heartbeatReset() override;
     PosPoint convertMissionItemToPosPoint(const mavsdk::MissionRawServer::MissionItem &item);

--- a/communication/vehicleserver.h
+++ b/communication/vehicleserver.h
@@ -30,6 +30,7 @@ public:
     virtual void setFollowPoint(QSharedPointer<FollowPoint> followPoint) = 0;
     virtual double getManualControlMaxSpeed() const = 0;
     virtual void sendGpsOriginLlh(const llh_t &gpsOriginLlh) = 0;
+    virtual void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) = 0;
 
 signals:
     void startWaypointFollower(bool fromBeginning);
@@ -54,7 +55,6 @@ protected:
     QTimer mHeartbeatTimer;
     const unsigned mCountdown_ms = 2000;
 
-    virtual void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) = 0;
     virtual void heartbeatTimeout() = 0;
     virtual void heartbeatReset() = 0;
 

--- a/communication/vehicleserver.h
+++ b/communication/vehicleserver.h
@@ -23,6 +23,7 @@ class VehicleServer : public QObject
 public:
     VehicleServer(QSharedPointer<VehicleState> vehicleState) : mVehicleState(vehicleState) {};
     virtual void setUbloxRover(QSharedPointer<UbloxRover> ubloxRover) = 0;
+    virtual void setGNSSReceiver(QSharedPointer<GNSSReceiver> gnssReceiver) { mGNSSReceiver = gnssReceiver; }
     virtual void setWaypointFollower(QSharedPointer<WaypointFollower> waypointFollower) = 0;
     virtual void setMovementController(QSharedPointer<MovementController> movementController) = 0;
     virtual void setManualControlMaxSpeed(double manualControlMaxSpeed_ms) = 0;
@@ -44,7 +45,7 @@ signals:
 
 protected:
     QSharedPointer<VehicleState> mVehicleState;
-    QSharedPointer<UbloxRover> mUbloxRover;
+    QSharedPointer<GNSSReceiver> mGNSSReceiver;
     QSharedPointer<WaypointFollower> mWaypointFollower;
     QSharedPointer<MovementController> mMovementController;
     QSharedPointer<FollowPoint> mFollowPoint;

--- a/examples/RCCar_ISO22133_autopilot/CMakeLists.txt
+++ b/examples/RCCar_ISO22133_autopilot/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(RCCar_ISO22133_autopilot
     ${WAYWISE_PATH}/sensors/gnss/ublox.cpp
     ${WAYWISE_PATH}/sensors/gnss/rtcm3_simple.cpp
     ${WAYWISE_PATH}/sensors/gnss/ubloxrover.cpp
+    ${WAYWISE_PATH}/sensors/gnss/gnssreceiver.cpp
     ${WAYWISE_PATH}/sensors/camera/gimbal.h
     ${WAYWISE_PATH}/communication/vehicleconnections/vehicleconnection.cpp
     ${WAYWISE_PATH}/communication/parameterserver.cpp

--- a/examples/RCCar_MAVLINK_autopilot/CMakeLists.txt
+++ b/examples/RCCar_MAVLINK_autopilot/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(RCCar_MAVLINK_autopilot
     ${WAYWISE_PATH}/sensors/gnss/ublox.cpp
     ${WAYWISE_PATH}/sensors/gnss/rtcm3_simple.cpp
     ${WAYWISE_PATH}/sensors/gnss/ubloxrover.cpp
+    ${WAYWISE_PATH}/sensors/gnss/gnssreceiver.cpp
     ${WAYWISE_PATH}/sensors/camera/gimbal.h
     ${WAYWISE_PATH}/communication/vehicleconnections/vehicleconnection.cpp
     ${WAYWISE_PATH}/communication/mavlinkparameterserver.cpp

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -1,0 +1,32 @@
+/*
+ *     Copyright 2024 Ramana Avula      ramana.reddy.avula@ri.se
+ *               2024 Marvin Damschen   marvin.damschen@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Abstract base class for GNSS receivers, supporting both real and simulated GNSS data.
+ */
+
+#include "gnssreceiver.h"
+
+GNSSReceiver::GNSSReceiver(QSharedPointer<VehicleState> vehicleState)
+{
+    mVehicleState = vehicleState;
+    mEnuReference = {57.71495867, 12.89134921, 0}; // AztaZero {57.7810, 12.7692, 0}, Klätterlabbet {57.6876, 11.9807, 0}, RISE RTK base station {57.71495867, 12.89134921, 0}
+}
+
+void GNSSReceiver::setEnuRef(llh_t enuRef)
+{
+    mEnuReference = enuRef;
+    mEnuReferenceSet = true;
+    emit updatedEnuReference(mEnuReference);
+}
+
+void GNSSReceiver::setIMUOrientationOffset(double roll_deg, double pitch_deg, double yaw_deg)
+{
+    mIMUOrientationOffset = {roll_deg, pitch_deg, yaw_deg};
+}
+
+void GNSSReceiver::setGNSSPositionOffset(double xOffset, double yOffset)
+{
+    mGNSSPositionOffset = {xOffset, yOffset, 0.0};
+}

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -1,0 +1,40 @@
+/*
+ *     Copyright 2024 Ramana Avula      ramana.reddy.avula@ri.se
+ *               2024 Marvin Damschen   marvin.damschen@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Abstract base class for GNSS receivers, supporting both real and simulated GNSS data.
+ */
+
+#ifndef GNSSRECEIVER_H
+#define GNSSRECEIVER_H
+
+#include <QObject>
+#include <QSharedPointer>
+
+#include "core/coordinatetransforms.h"
+#include "vehicles/vehiclestate.h"
+
+class GNSSReceiver : public QObject
+{
+    Q_OBJECT
+public:
+    GNSSReceiver(QSharedPointer<VehicleState> vehicleState);
+
+    virtual llh_t getEnuRef() const { return mEnuReference; }
+    virtual void setEnuRef(llh_t enuRef);
+    virtual void setIMUOrientationOffset(double roll_deg, double pitch_deg, double yaw_deg);
+    virtual void setGNSSPositionOffset(double xOffset, double yOffset);
+
+signals:
+    void updatedEnuReference(llh_t mEnuReference);
+
+protected:
+    llh_t mEnuReference;
+    bool mEnuReferenceSet = false;
+    QSharedPointer<VehicleState> mVehicleState;
+    struct {double rollOffset_deg, pitchOffset_deg, yawOffset_deg;} mIMUOrientationOffset;
+    xyz_t mGNSSPositionOffset = {0.0, 0.0, 0.0};
+};
+
+#endif // GNSSRECEIVER_H

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -12,23 +12,18 @@
 #include <QObject>
 #include <QSharedPointer>
 #include "ublox.h"
-#include "core/coordinatetransforms.h"
-#include "vehicles/vehiclestate.h"
+#include "gnssreceiver.h"
 
-class UbloxRover : public QObject
+class UbloxRover : public GNSSReceiver
 {
     Q_OBJECT
 public:
     UbloxRover(QSharedPointer<VehicleState> vehicleState);
     bool connectSerial(const QSerialPortInfo &serialPortInfo);
     bool isSerialConnected();
-    llh_t getEnuRef() const;
-    void setEnuRef(llh_t enuRef);
     void writeRtcmToUblox(QByteArray data);
     void writeOdoToUblox(ubx_esf_datatype_enum dataType, uint32_t dataField);
     void saveOnShutdown();
-    void setIMUOrientationOffset(double roll_deg, double pitch_deg, double yaw_deg);
-    void setGNSSPositionOffset(double xOffset, double yOffset);
 
 signals:
     void updatedGNSSPositionAndYaw(QSharedPointer<VehicleState> vehicleState, double distanceMoved, bool fused);
@@ -41,14 +36,7 @@ private:
     void updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt);
 
     const int ms_per_day = 24 * 60 * 60 * 1000;
-
-    llh_t mEnuReference;
-    bool mEnuReferenceSet = false;
-
     Ublox mUblox;
-    QSharedPointer<VehicleState> mVehicleState;
-    struct {double rollOffset_deg, pitchOffset_deg, yawOffset_deg;} mIMUOrientationOffset;
-    xyz_t mGNSSPositionOffset = {0.0, 0.0, 0.0};
 };
 
 #endif // UBLOXROVER_H


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature

* **What is the current behavior?** (You can also link to an open issue here)

  UbloxRover maintains enuref for vehicles and UbloxRover and MAVSDK vehicle server are tightly coupled. The MAVSDK vehicle server only publishes enuref when the UbloxRover is instantiated. This behavior creates an issue when using WayWise with simulators such as CARLA since the vehicle wont have an enuref to understand the route sent from controltower. 

* **What is the new behavior (if this is a feature change)?**

  A base GNSSReceiver class is created that currently only maintains the enuref, but eventually it could bring support to GNSS receivers other than ublox and even simulated/emulated ones. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  Yes, the following changes need to be implemented due to this PR:
  -  sensors/gnss/gnssreceiver.cpp should be added to the source list of the executable when using UbloxRover or VehicleServer classes.


* **Other information**:


