### PR TITLE
Update readme and copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WayWise
 ![Workflow build result](https://github.com/RISE-Dependable-Transport-Systems/WayWise/actions/workflows/main.yml/badge.svg)
 
-![ww](https://user-images.githubusercontent.com/2404625/166413759-d1d2f771-984c-4dec-9036-866cf29dc547.png)
+https://github.com/user-attachments/assets/22279eb2-fc61-4fe6-91da-493cc589b09c
 
 WayWise ([way-wise](https://en.wiktionary.org/wiki/way-wise): _Expert or knowledgeable in finding or keeping the way; knowing the way or route._) is a rapid prototyping library for connected, autonomous vehicles.
 It is developed within research projects at the RISE Dependable Transport Systems group to investigate the use of autonomous vehicles (rc cars, tractors, drones) and, especially, related functional safety as well as cybersecurity risks and opportunities they bring, in various use cases (road traffic, agriculture, maritime).

--- a/README.md
+++ b/README.md
@@ -7,47 +7,66 @@ WayWise ([way-wise](https://en.wiktionary.org/wiki/way-wise): _Expert or knowled
 It is developed within research projects at the RISE Dependable Transport Systems group to investigate the use of autonomous vehicles (rc cars, tractors, drones) and, especially, related functional safety as well as cybersecurity risks and opportunities they bring, in various use cases (road traffic, agriculture, maritime).
 It has roots in the [RISE Self-Driving Vehicle Platform (SDVP)](https://github.com/RISE-Dependable-Transport-Systems/rise_sdvp), originally developed by Benjamin Vedder, but was redesigned and rewritten based on C++ and Qt targeting commercial-of-the-shelf hardware (instead of custom hardware and firmware).
 The library is used to build the brains on-vehicle and the control application counterpart on the desktop.
-Vehicle and control application communicate with each other using the [MAVLINK protocol](https://mavlink.io/), which is implemented using [MAVSDK](http://mavsdk.io/).
+The main protocol for communication between vehicle and control application is [MAVLINK](https://mavlink.io/), which is implemented using [MAVSDK](http://mavsdk.io/).
+There is also support for controlling vehicles using [ISO/TS 22133:2023](https://www.iso.org/standard/78970.html) as implemented in [RI-SE/iso22133](https://github.com/RI-SE/iso22133).
 WayWise does not target production readiness but exploring specific use cases by rapid prototyping.
 
-Main authors are (firstname.lastname@ri.se):
+Our main projects that base on WayWise are:
+- [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower), desktop control application that communicates to vehicles via MAVLINK (WayWise-based vehicles mainly, experimental [PX4](https://px4.io/) support).
+- [RCCar](https://github.com/RISE-Dependable-Transport-Systems/RCCar), a fully-fledged rc car implementation (GNSS & IMU-based positioning, [VESC](https://vesc-project.com/)-based odometry, ...).
+- [WayWiseR](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR), a ROS2 integration of WayWise that streamlines the development and deployment of autonomous vehicles in both simulation and real-world environments.
+
+Current maintainers are:
 - Marvin Damschen
-- Rickard Häll
 - Aria Mirzai
+- Ramana Reddy Avula
+
+Previous maintainers:
+- Rickard Häll
+
+You can reach out to us directly or via waywise@ri.se.
 
 ## How to use it and what to expect
 This "library" is meant to be used as a git submodule, as we do not do releases (for the time being) and do not promise a stable API.
 In general, our development resources are scarce and dedicated to fulfill use cases of research projects we are part of.
 We do our best to avoid it, but things will break from time to time.
 
-A minimal example of a simulated rc car with an autopilot can be found here: \
-https://github.com/RISE-Dependable-Transport-Systems/RCCar_minimal_example \
-This example can be connected to using [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower) and follow waypoints created on the map:
+As set of examples can be found in [/examples](https://github.com/RISE-Dependable-Transport-Systems/WayWise/tree/main/examples), most notably:
+- [A minimal simulated car with an autopilot communicating via MAVLINK](https://github.com/RISE-Dependable-Transport-Systems/WayWise/tree/main/examples/RCCar_MAVLINK_autopilot). This example can be connected to using [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower) and follow waypoints created on the map (see screen recording below).
+- [A minimal simulated car with an autopilot communicating via ISO/TS 22133](https://github.com/RISE-Dependable-Transport-Systems/WayWise/tree/main/examples/RCCar_ISO22133_autopilot). This example can be connected to using [ATOS](https://github.com/RI-SE/ATOS).
 
 ![RCCar_minimal_example](https://user-images.githubusercontent.com/2404625/202208555-1271ba0d-55f7-4c26-94ac-53920e6d18c5.gif)
-
-A fully-fledged rc car implementation (GNSS & IMU-based positioning, [VESC](https://vesc-project.com/)-based odometry, ...) can be found here: \
-https://github.com/RISE-Dependable-Transport-Systems/RCCar
-
-### Current state
-The biggest general construction sites are documentation and improving [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower).
-ControlTower was built from scratch within the [LASH FIRE](https://lashfire.eu/) EU project and recently (#19) replaced [RControlStation](https://github.com/RISE-Dependable-Transport-Systems/rise_sdvp/tree/master/Linux/RControlStation) from SDVP times. 
-ControlTower communicates to vehicles via MAVLINK, which enables support for drones running [PX4](https://px4.io/) additionally to WayWise-based vehicles.
 
 ## Organization
 - **core**: fundamental classes/headers, e.g., for storing a position and transforming coordinates
 - **communication**: quite broadly, everything that deals with "communication", e.g., connection between vehicle and control station, but also the vehicle's internal communication to lower-level control via CANopen
+- **logger**: logging functionallity between vehicles and control application
 - **vehicles**: classes used to store state of different vehicle types (e.g., within desktop application), but also to implement a specific vehicle that can drive and steer using controllers
 - **sensors**: sensor support in a broad sense. Support for GNSS, IMU and UWB-based positioning is implemented here as well as objectdetection using [DepthAI](https://docs.luxonis.com/en/latest/)
 - **autopilot**: currently provides the "WaypointFollower" interface for following a route (i.e., a list of waypoints) and several implementations of it
   - PurePursuitWaypointFollower, an implementation of [pure pursuit](https://www.ri.cmu.edu/pub_files/pub3/coulter_r_craig_1992_1/coulter_r_craig_1992_1.pdf), which can also follow a point, e.g., a person or another vehicle
   - GotoWaypointFollower, does not do low-level control but sends goto requests (mainly used for PX4-based drones)
   - MultiWaypointFollower, is a container that allows switching between multiple instances of WaypointFollower (e.g., if you want to switch between different routes and save state inbetween)
-- **userinterface**: UI building blocks to create desktop applications. Functional but still a lot of work-in-progress (see also [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower))
+- **userinterface**: UI building blocks to create desktop applications (see also [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower))
 - **external**: code from external projects
+- **tools**: tools that support WayWise development like for building MAVSDK
+- **examples**: a set of examples showing how WayWise is used
 
 ## Use cases
 ![image](https://user-images.githubusercontent.com/2404625/165902491-023a640b-947a-4a76-aea6-6219e5f8ca76.png)
+
+## Citation
+If you use WayWise in a publication, please cite our [paper](https://doi.org/10.1016/j.simpa.2024.100682):
+
+    @article{Damschen_WayWise_A_rapid_2024,
+    author = {Damschen, Marvin and Häll, Rickard and Mirzai, Aria},
+    doi = {10.1016/j.simpa.2024.100682},
+    journal = {Software Impacts},
+    month = sep,
+    title = {{WayWise: A rapid prototyping library for connected, autonomous vehicles}},
+    volume = {21},
+    year = {2024}
+    }
 
 ## Funded by
 <img src="https://user-images.githubusercontent.com/2404625/202213271-a4006999-49d5-4e61-9f3d-867a469238d1.png" width="120" height="81" align="left" alt="EU logo" />

--- a/autopilot/emergencybrake.cpp
+++ b/autopilot/emergencybrake.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "emergencybrake.h"

--- a/autopilot/emergencybrake.h
+++ b/autopilot/emergencybrake.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Uses sensor inputs to take emergency brake decision

--- a/autopilot/followpoint.cpp
+++ b/autopilot/followpoint.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/autopilot/followpoint.h
+++ b/autopilot/followpoint.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Follow a person or other vehicle when the point to follow is continously updated.

--- a/autopilot/gotowaypointfollower.cpp
+++ b/autopilot/gotowaypointfollower.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/autopilot/gotowaypointfollower.h
+++ b/autopilot/gotowaypointfollower.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implementation of WaypointFollower to control autopilot through VehicleConnection

--- a/autopilot/multiwaypointfollower.cpp
+++ b/autopilot/multiwaypointfollower.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/autopilot/multiwaypointfollower.h
+++ b/autopilot/multiwaypointfollower.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Holds multiple waypointfollowers to enable switching between routes.

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include <cmath>

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implementation of pure pursuit for following a list of waypoints ("Follow Route").

--- a/autopilot/waypointfollower.h
+++ b/autopilot/waypointfollower.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract class to control autopilot

--- a/communication/CANopen/canopencontrollerinterface.cpp
+++ b/communication/CANopen/canopencontrollerinterface.cpp
@@ -1,8 +1,6 @@
 ﻿/*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- *
  */
 
 #include <QAbstractEventDispatcher>

--- a/communication/CANopen/canopencontrollerinterface.h
+++ b/communication/CANopen/canopencontrollerinterface.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Creating a CANopen node and connecting relevant data to be sent and received on the CAN bus.

--- a/communication/CANopen/canopenmovementcontroller.cpp
+++ b/communication/CANopen/canopenmovementcontroller.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/communication/CANopen/canopenmovementcontroller.h
+++ b/communication/CANopen/canopenmovementcontroller.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implementation of MovementController for controll over CANopen.

--- a/communication/CANopen/slave.cpp
+++ b/communication/CANopen/slave.cpp
@@ -1,7 +1,6 @@
 /*
- *     Copyright 2021 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
  */
 
 #include <QDebug>

--- a/communication/CANopen/slave.h
+++ b/communication/CANopen/slave.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implements CAN bus communication as defined in cpp-slave.eds. Communication following the CANopen standard 301.  

--- a/communication/jsonstreamparsertcp.cpp
+++ b/communication/jsonstreamparsertcp.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "jsonstreamparsertcp.h"

--- a/communication/jsonstreamparsertcp.h
+++ b/communication/jsonstreamparsertcp.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Class that connects to a TCP port which is assumed to stream newline-delimited JSON objects and/or arrays, parses stream and makes data available using signals

--- a/communication/mavlinkparameterserver.cpp
+++ b/communication/mavlinkparameterserver.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/communication/mavlinkparameterserver.h
+++ b/communication/mavlinkparameterserver.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/communication/parameterserver.cpp
+++ b/communication/parameterserver.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include <QDebug>

--- a/communication/parameterserver.h
+++ b/communication/parameterserver.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/communication/vehicleconnections/mavsdkstation.cpp
+++ b/communication/vehicleconnections/mavsdkstation.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *     Copyright 2024 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "mavsdkstation.h"

--- a/communication/vehicleconnections/mavsdkstation.h
+++ b/communication/vehicleconnections/mavsdkstation.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *     Copyright 2024 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * "Control station" that accepts vehicle connections via MAVLINK using MAVSDK

--- a/communication/vehicleconnections/mavsdkvehicleconnection.cpp
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "mavsdkvehicleconnection.h"

--- a/communication/vehicleconnections/mavsdkvehicleconnection.h
+++ b/communication/vehicleconnections/mavsdkvehicleconnection.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implementation of VehicleConnection to communicate with MAVLINK-based vehicles using MAVSDK

--- a/communication/vehicleconnections/vehicleconnection.cpp
+++ b/communication/vehicleconnections/vehicleconnection.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2023 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "vehicleconnection.h"

--- a/communication/vehicleconnections/vehicleconnection.h
+++ b/communication/vehicleconnections/vehicleconnection.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract class to communicate with a vehicle using a remote VehicleConnection

--- a/communication/vehicleserver.h
+++ b/communication/vehicleserver.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/core/coordinatetransforms.h
+++ b/core/coordinatetransforms.h
@@ -1,7 +1,5 @@
 /*
- *     Copyright 2016 - 2017 Benjamin Vedder	benjamin@vedder.se
- *               2021        Marvin Damschen    marvin.damschen@ri.se
- *               2024        Rickard Häll       rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Header-only coordinate transformations, mainly ENU <-> latitude, longitude, height

--- a/core/geometry.h
+++ b/core/geometry.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Namespace to hold general geometric calculations

--- a/core/pospoint.cpp
+++ b/core/pospoint.cpp
@@ -1,19 +1,6 @@
 /*
-    Copyright 2012 Benjamin Vedder	benjamin@vedder.se
-              2020 Marvin Damschen  marvin.damschen@ri.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2020 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #include "pospoint.h"

--- a/core/pospoint.h
+++ b/core/pospoint.h
@@ -1,19 +1,6 @@
 /*
-    Copyright 2012         Benjamin Vedder  benjamin@vedder.se
-              2020 - 2022  Marvin Damschen  marvin.damschen@ri.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #ifndef POSPOINT_H

--- a/core/simplewatchdog.cpp
+++ b/core/simplewatchdog.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "simplewatchdog.h"

--- a/core/simplewatchdog.h
+++ b/core/simplewatchdog.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * A simple class to detect when Qt's event loop takes longer than expected

--- a/logger/logger.cpp
+++ b/logger/logger.cpp
@@ -1,5 +1,6 @@
 /*
- *  Author: Aria Mirzai, aria.mirzai@ri.se (2023)
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 #include <QDateTime>

--- a/logger/logger.h
+++ b/logger/logger.h
@@ -1,5 +1,6 @@
 /*
- *  Author: Aria Mirzai, aria.mirzai@ri.se (2023)
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 #ifndef LOGGER_H

--- a/routeplanning/zigzagroutegenerator.cpp
+++ b/routeplanning/zigzagroutegenerator.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "zigzagroutegenerator.h"

--- a/routeplanning/zigzagroutegenerator.h
+++ b/routeplanning/zigzagroutegenerator.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef ZIGZAGROUTEGENERATOR_H

--- a/sensors/angle/anglesensorupdater.cpp
+++ b/sensors/angle/anglesensorupdater.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 RISE Sweden
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "anglesensorupdater.h"

--- a/sensors/angle/anglesensorupdater.h
+++ b/sensors/angle/anglesensorupdater.h
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Abstract interface for receiving angle values e.g., magnetic rotary position sensor 
  */
 

--- a/sensors/angle/as5600updater.cpp
+++ b/sensors/angle/as5600updater.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "as5600updater.h"

--- a/sensors/angle/as5600updater.h
+++ b/sensors/angle/as5600updater.h
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Implementation of angle sensor specific for AS5600
  */
 

--- a/sensors/camera/depthaicamera.cpp
+++ b/sensors/camera/depthaicamera.cpp
@@ -1,8 +1,7 @@
 /*
- *     Copyright 2021 Rickard Häll      rickard.hall@ri.se
- *               2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Class to parse a JSON stream with object detections (incl. depth information) from DepthAI
  */
 #include "depthaicamera.h"

--- a/sensors/camera/depthaicamera.h
+++ b/sensors/camera/depthaicamera.h
@@ -1,8 +1,7 @@
 /*
- *     Copyright 2021 Rickard Häll      rickard.hall@ri.se
- *               2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Class to parse a JSON stream with object detections (incl. depth information) from DepthAI
  */
 

--- a/sensors/camera/gimbal.h
+++ b/sensors/camera/gimbal.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef GIMBAL_H

--- a/sensors/camera/mavsdkgimbal.cpp
+++ b/sensors/camera/mavsdkgimbal.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "mavsdkgimbal.h"

--- a/sensors/camera/mavsdkgimbal.h
+++ b/sensors/camera/mavsdkgimbal.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef MAVSDKGIMBAL_H

--- a/sensors/fusion/sdvpvehiclepositionfuser.cpp
+++ b/sensors/fusion/sdvpvehiclepositionfuser.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "sdvpvehiclepositionfuser.h"

--- a/sensors/fusion/sdvpvehiclepositionfuser.h
+++ b/sensors/fusion/sdvpvehiclepositionfuser.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Rewritten and restructured version of SDVP's sensor "fusion" algorithm for obtaining position and orientation 

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2024 Ramana Avula      ramana.reddy.avula@ri.se
- *               2024 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract base class for GNSS receivers, supporting both real and simulated GNSS data.

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2024 Ramana Avula      ramana.reddy.avula@ri.se
- *               2024 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract base class for GNSS receivers, supporting both real and simulated GNSS data.

--- a/sensors/gnss/rtcm3_simple.cpp
+++ b/sensors/gnss/rtcm3_simple.cpp
@@ -1,18 +1,6 @@
 /*
-    Copyright 2016 - 2017 Benjamin Vedder	benjamin@vedder.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2017 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 // This code is based on the implementation found in rtklib by T.TAKASU.

--- a/sensors/gnss/rtcm3_simple.h
+++ b/sensors/gnss/rtcm3_simple.h
@@ -1,18 +1,6 @@
 /*
-    Copyright 2016 - 2017 Benjamin Vedder	benjamin@vedder.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2017 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 #ifndef RTCM3_SIMPLE_H

--- a/sensors/gnss/rtcmclient.cpp
+++ b/sensors/gnss/rtcmclient.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "rtcmclient.h"

--- a/sensors/gnss/rtcmclient.h
+++ b/sensors/gnss/rtcmclient.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Connects to NTRIP / RTCM server (TCP/IP) and streams received messages using singal/slot

--- a/sensors/gnss/ublox.cpp
+++ b/sensors/gnss/ublox.cpp
@@ -1,20 +1,6 @@
 /*
-    Copyright 2017 - 2018 Benjamin Vedder   benjamin@vedder.se
-              2020 - 2022 Marvin Damschen   marvin.damschen@ri.se
-              2021 - 2022 Rickard Häll      rickard.hall@ri.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 #include "ublox.h"

--- a/sensors/gnss/ublox.h
+++ b/sensors/gnss/ublox.h
@@ -1,20 +1,6 @@
 /*
-    Copyright 2017 - 2018 Benjamin Vedder   benjamin@vedder.se
-              2020 - 2022 Marvin Damschen   marvin.damschen@ri.se
-              2021 - 2022 Rickard Häll      rickard.hall@ri.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 #ifndef UBLOX_H

--- a/sensors/gnss/ublox_basestation.cpp
+++ b/sensors/gnss/ublox_basestation.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2020  Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2020 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "ublox_basestation.h"

--- a/sensors/gnss/ublox_basestation.h
+++ b/sensors/gnss/ublox_basestation.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2020  Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2020 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Sets up u-blox GNSS reciver connected over serial as a basestation. Supports/tested with F9P/F9R only for now.

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "ubloxrover.h"

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -1,8 +1,7 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Implements communication with a moving u-blox-based GNSS receiver
  */
 

--- a/sensors/imu/bno055orientationupdater.cpp
+++ b/sensors/imu/bno055orientationupdater.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "bno055orientationupdater.h"

--- a/sensors/imu/bno055orientationupdater.h
+++ b/sensors/imu/bno055orientationupdater.h
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Implementation of IMUOrientationUpdater for Bosch BNO055 IMUs
  */
 

--- a/sensors/imu/imuorientationupdater.cpp
+++ b/sensors/imu/imuorientationupdater.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "imuorientationupdater.h"

--- a/sensors/imu/imuorientationupdater.h
+++ b/sensors/imu/imuorientationupdater.h
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Abstract interface for receiving orientation data from IMUs
  */
 

--- a/sensors/tof/tofsensor.h
+++ b/sensors/tof/tofsensor.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract interface for receiving distance values from a Time of Flight (ToF) sensor

--- a/sensors/tof/vl53l0xtofsensor.cpp
+++ b/sensors/tof/vl53l0xtofsensor.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "vl53l0xtofsensor.h"

--- a/sensors/tof/vl53l0xtofsensor.h
+++ b/sensors/tof/vl53l0xtofsensor.h
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Implementation of tof sensor specific for VL53L0X
  */
 

--- a/sensors/uwb/pozyxpositionupdater.cpp
+++ b/sensors/uwb/pozyxpositionupdater.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "pozyxpositionupdater.h"

--- a/sensors/uwb/pozyxpositionupdater.h
+++ b/sensors/uwb/pozyxpositionupdater.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Quite simple implementation of UWB-based positioning using Pozyx

--- a/userinterface/cameragimbalui.cpp
+++ b/userinterface/cameragimbalui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "cameragimbalui.h"

--- a/userinterface/cameragimbalui.h
+++ b/userinterface/cameragimbalui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef CAMERAGIMBALUI_H

--- a/userinterface/driveui.cpp
+++ b/userinterface/driveui.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/userinterface/driveui.h
+++ b/userinterface/driveui.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/userinterface/flyui.cpp
+++ b/userinterface/flyui.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2024 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "flyui.h"

--- a/userinterface/flyui.h
+++ b/userinterface/flyui.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
- *               2024 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * UI building block for flying a multicopter-type vehicle

--- a/userinterface/map/mapwidget.cpp
+++ b/userinterface/map/mapwidget.cpp
@@ -1,19 +1,6 @@
 /*
-    Copyright 2012 - 2019 Benjamin Vedder	benjamin@vedder.se
-              2020 - 2022 Marvin Damschen  marvin.damschen@ri.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #include <QDebug>

--- a/userinterface/map/mapwidget.h
+++ b/userinterface/map/mapwidget.h
@@ -1,19 +1,6 @@
 /*
-    Copyright 2012 - 2019 Benjamin Vedder	benjamin@vedder.se
-              2020 - 2022 Marvin Damschen  marvin.damschen@ri.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #ifndef MAPWIDGET_H

--- a/userinterface/map/osmclient.cpp
+++ b/userinterface/map/osmclient.cpp
@@ -1,18 +1,6 @@
 /*
-    Copyright 2016 Benjamin Vedder	benjamin@vedder.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2016 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #include "osmclient.h"

--- a/userinterface/map/osmclient.h
+++ b/userinterface/map/osmclient.h
@@ -1,18 +1,6 @@
 /*
-    Copyright 2016 Benjamin Vedder	benjamin@vedder.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2016 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #ifndef OSMCLIENT_H

--- a/userinterface/map/osmtile.cpp
+++ b/userinterface/map/osmtile.cpp
@@ -1,18 +1,6 @@
 /*
-    Copyright 2016 Benjamin Vedder	benjamin@vedder.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2016 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #include "osmtile.h"

--- a/userinterface/map/osmtile.h
+++ b/userinterface/map/osmtile.h
@@ -1,18 +1,6 @@
 /*
-    Copyright 2016 Benjamin Vedder	benjamin@vedder.se
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *     Copyright 2016 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
     */
 
 #ifndef OSMTILE_H

--- a/userinterface/map/routeplannermodule.cpp
+++ b/userinterface/map/routeplannermodule.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "routeplannermodule.h"

--- a/userinterface/map/routeplannermodule.h
+++ b/userinterface/map/routeplannermodule.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * MapModule that allows creating and interacting with routes on the map

--- a/userinterface/map/tracemodule.cpp
+++ b/userinterface/map/tracemodule.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "tracemodule.h"

--- a/userinterface/map/tracemodule.h
+++ b/userinterface/map/tracemodule.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * MapModule that traces the different vehicles' position types, manages them and draws them on the map

--- a/userinterface/planui.cpp
+++ b/userinterface/planui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "planui.h"

--- a/userinterface/planui.h
+++ b/userinterface/planui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * UI building block for planning routes

--- a/userinterface/routegeneratorui.cpp
+++ b/userinterface/routegeneratorui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "routegeneratorui.h"

--- a/userinterface/routegeneratorui.h
+++ b/userinterface/routegeneratorui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef ROUTEGENERATORUI_H

--- a/userinterface/routegeneratorzigzagui.cpp
+++ b/userinterface/routegeneratorzigzagui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "routegeneratorzigzagui.h"

--- a/userinterface/routegeneratorzigzagui.h
+++ b/userinterface/routegeneratorzigzagui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef ROUTEGENERATORZIGZAGUI_H

--- a/userinterface/serialportdialog.cpp
+++ b/userinterface/serialportdialog.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "serialportdialog.h"

--- a/userinterface/serialportdialog.h
+++ b/userinterface/serialportdialog.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #ifndef SERIALPORTDIALOG_H

--- a/userinterface/traceui.cpp
+++ b/userinterface/traceui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "traceui.h"

--- a/userinterface/traceui.h
+++ b/userinterface/traceui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * UI building block for tracing the vehicles' different position types

--- a/userinterface/ubloxbasestationui.cpp
+++ b/userinterface/ubloxbasestationui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "ubloxbasestationui.h"

--- a/userinterface/ubloxbasestationui.h
+++ b/userinterface/ubloxbasestationui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * UI building block for running a (u-blox receiver-based) GNSS basestation sending RTK correction data via RTCM

--- a/userinterface/vehicleparameterui.cpp
+++ b/userinterface/vehicleparameterui.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include <iomanip>

--- a/userinterface/vehicleparameterui.h
+++ b/userinterface/vehicleparameterui.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/vehicles/carstate.cpp
+++ b/vehicles/carstate.cpp
@@ -1,10 +1,7 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Lukas Wikander    lukas.wikander@astazero.com
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Specific implementation of VehicleState for car-type (ackermann) vehicles, storing all (dynamic and static) state
  */
 #include "carstate.h"

--- a/vehicles/carstate.h
+++ b/vehicles/carstate.h
@@ -1,9 +1,7 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Lukas Wikander    lukas.wikander@astazero.com
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Specific implementation of VehicleState for car-type (ackermann) vehicles, storing all (dynamic and static) state
  */
 

--- a/vehicles/controller/carmovementcontroller.cpp
+++ b/vehicles/controller/carmovementcontroller.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "carmovementcontroller.h"

--- a/vehicles/controller/carmovementcontroller.h
+++ b/vehicles/controller/carmovementcontroller.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implementation of MovementController for car-type (ackermann) vehicles.

--- a/vehicles/controller/motorcontroller.h
+++ b/vehicles/controller/motorcontroller.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract class that provides an interface to talk to motor controllers, e.g., to be used within a MovementController

--- a/vehicles/controller/movementcontroller.cpp
+++ b/vehicles/controller/movementcontroller.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "movementcontroller.h"

--- a/vehicles/controller/movementcontroller.h
+++ b/vehicles/controller/movementcontroller.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract class to provide interface towards, e.g., autopilot, and to be implemented for specific vehicle types.

--- a/vehicles/controller/servocontroller.cpp
+++ b/vehicles/controller/servocontroller.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "servocontroller.h"

--- a/vehicles/controller/servocontroller.h
+++ b/vehicles/controller/servocontroller.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Abstract class that provides an interface to talk to servos, e.g., to be used within a MovementController

--- a/vehicles/controller/vescmotorcontroller.cpp
+++ b/vehicles/controller/vescmotorcontroller.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "vescmotorcontroller.h"

--- a/vehicles/controller/vescmotorcontroller.h
+++ b/vehicles/controller/vescmotorcontroller.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Implementation of the abstract MotorController for "VESC" motor controllers.

--- a/vehicles/copterstate.cpp
+++ b/vehicles/copterstate.cpp
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2020 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Specific implementation of VehicleState for multicopter drones/UAVs, storing all (dynamic and static) state

--- a/vehicles/copterstate.h
+++ b/vehicles/copterstate.h
@@ -1,6 +1,5 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2020 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Specific implementation of VehicleState for multicopter drones/UAVs, storing all (dynamic and static) state

--- a/vehicles/diffdrivevehiclestate.cpp
+++ b/vehicles/diffdrivevehiclestate.cpp
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Specific implementation of VehicleState for differential vehicles, storing all (dynamic and static) state
  */
 #include "diffdrivevehiclestate.h"

--- a/vehicles/diffdrivevehiclestate.h
+++ b/vehicles/diffdrivevehiclestate.h
@@ -1,7 +1,7 @@
 /*
- *     Copyright 2021 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Specific implementation of VehicleState for differential vehicles, storing all (dynamic and static) state
  */
 

--- a/vehicles/objectstate.cpp
+++ b/vehicles/objectstate.cpp
@@ -1,7 +1,5 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Lukas Wikander    lukas.wikander@astazero.com
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 

--- a/vehicles/objectstate.h
+++ b/vehicles/objectstate.h
@@ -1,9 +1,7 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Lukas Wikander    lukas.wikander@astazero.com
+ *     Copyright 2021 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Core class for storing all state (static and dynamic) of a moveable or immovable object (e.g., vehicle, camera, ...)
  */
 

--- a/vehicles/trailerstate.cpp
+++ b/vehicles/trailerstate.cpp
@@ -1,7 +1,6 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- *
  */
 
 #include "trailerstate.h"

--- a/vehicles/trailerstate.h
+++ b/vehicles/trailerstate.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Specialisation of VehicleState for tailer state

--- a/vehicles/truckstate.cpp
+++ b/vehicles/truckstate.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 RISE Sweden
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * Specific implementation of VehicleState for car-type (ackermann) vehicles, storing all (dynamic and static) state

--- a/vehicles/truckstate.h
+++ b/vehicles/truckstate.h
@@ -1,7 +1,6 @@
 /*
- *     Copyright 2024 RISE Sweden
- *
- *   Specific implementation of VehicleState for car-type (ackermann) vehicles, storing all (dynamic and static) state
+ *     Copyright 2024 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 #ifndef TRUCKSTATE_H

--- a/vehicles/vehiclelighting.cpp
+++ b/vehicles/vehiclelighting.cpp
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  *     Code adapted from example:

--- a/vehicles/vehiclelighting.h
+++ b/vehicles/vehiclelighting.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2023 Rickard Häll   rickard.hall@ri.se
+ *     Copyright 2023 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  *
  *     Code adapted from example:

--- a/vehicles/vehiclestate.cpp
+++ b/vehicles/vehiclestate.cpp
@@ -1,8 +1,5 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Lukas Wikander    lukas.wikander@astazero.com
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 #include "vehiclestate.h"

--- a/vehicles/vehiclestate.h
+++ b/vehicles/vehiclestate.h
@@ -1,10 +1,7 @@
 /*
- *     Copyright 2012 Benjamin Vedder   benjamin@vedder.se
- *               2020 Marvin Damschen   marvin.damschen@ri.se
- *               2021 Lukas Wikander    lukas.wikander@astazero.com
- *               2022 Rickard Häll      rickard.hall@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
- * 
+ *
  * Specialisation of ObjectState for vehicles, storing all (dynamic and static) state
  */
 

--- a/waywise.h
+++ b/waywise.h
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2022 Marvin Damschen   marvin.damschen@ri.se
+ *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
  *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
  */
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update. README.md was outdated.
Further, copyright statements are updated to:

```
/*
 *     Copyright 2022 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
 *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
 */
```

Naming individuals as copyright holders for our files is not correct, and IMO it is not needed to have individual names (this is what the commit history is for 🙂).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Docs change only.



