### PR TITLE
Feature/speedregions

### DIFF
--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -587,26 +587,9 @@ QList<SpeedLimitRegion> PurepursuitWaypointFollower::getSpeedLimitRegions() cons
 
 void PurepursuitWaypointFollower::loadSpeedLimitRegionsFile()
 {
-    QDir documentsDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));   // OS agnostic
-
-    QString folderName = "WayWise Speed Limits";
-    QString folderPath = documentsDirectory.filePath(folderName);
-
-    if (!documentsDirectory.exists(folderPath)) {
-        if (documentsDirectory.mkpath(folderPath)) {
-            qInfo() << "Speed limits folder created";
-        } else {
-            qWarning() << "Failed to create speed limits folder";
-            return;
-        }
-    }
-
-    QString fileName = "speedLimitRegions.json";
-    QString filePath = documentsDirectory.filePath(folderName + "/" + fileName);
-
-    QFile file(filePath);
+    QFile file(mSpeedLimitRegionsFilePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        qInfo() << "Could not open speed limit regions file:" << filePath << Qt::endl
+        qInfo() << "Could not open speed limit regions file:" << mSpeedLimitRegionsFilePath << Qt::endl
                 << "To create speed limit regions:" << Qt::endl
                 << "1. Go to https://geojson.io/#map=2/0/20 to easily define Polygons geometry" << Qt::endl
                 << "2. Copy the JSON source (make sure type is 'FeatureCollection')" << Qt::endl

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -8,12 +8,26 @@
 #include "purepursuitwaypointfollower.h"
 #include "communication/parameterserver.h"
 #include "core/geometry.h"
+#include "routeplanning/zigzagroutegenerator.h"
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QDir>
+#include <QStandardPaths>
 
 PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<MovementController> movementController)
 {
     mMovementController = movementController;
     mVehicleState = mMovementController->getVehicleState();
     connect(&mUpdateStateTimer, &QTimer::timeout, this, &PurepursuitWaypointFollower::updateState);
+
+    loadSpeedLimitRegionsFile();    // uses the default ENU reference (for simulation)
+    connect(mVehicleState.get(), &VehicleState::updatedEnuReference, this, [this]() {
+        qInfo() << "New ENU reference received, reloading speed limit regions.";
+
+        clearSpeedLimitRegions();
+        loadSpeedLimitRegionsFile();
+    });
 }
 
 PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<VehicleConnection> vehicleConnection, PosType posTypeUsed)
@@ -22,6 +36,14 @@ PurepursuitWaypointFollower::PurepursuitWaypointFollower(QSharedPointer<VehicleC
     mVehicleState = mVehicleConnection->getVehicleState();
     connect(&mUpdateStateTimer, &QTimer::timeout, this, &PurepursuitWaypointFollower::updateState);
     setPosTypeUsed(posTypeUsed);
+
+    loadSpeedLimitRegionsFile();    // uses the default ENU reference (for simulation)
+    connect(mVehicleState.get(), &VehicleState::updatedEnuReference, this, [this]() {
+        qInfo() << "New ENU reference received, reloading speed limit regions.";
+
+        clearSpeedLimitRegions();
+        loadSpeedLimitRegionsFile();
+    });
 }
 
 void PurepursuitWaypointFollower::provideParametersToParameterServer()
@@ -205,7 +227,7 @@ void PurepursuitWaypointFollower::updateState()
 
         if (intersections.size()) {
             mCurrentState.currentGoal.setXY(intersections[0].x(), intersections[0].y());
-            updateControl(mCurrentState.currentGoal);
+            trol(mCurrentState.currentGoal);
         } else { // first waypoint within circle -> start route
             if (mWaypointList.size() > 1) {
                 mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
@@ -297,7 +319,7 @@ void PurepursuitWaypointFollower::updateState()
             mCurrentState.currentGoal.setAttributes(closestWaypoint.getAttributes());
 
             // 4. Update control for current goal
-            updateControl(mCurrentState.currentGoal);
+            trol(mCurrentState.currentGoal);
         }
     } break;
     case WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL: {
@@ -357,7 +379,7 @@ void PurepursuitWaypointFollower::updateState()
                 } else {
                     mCurrentState.currentGoal.setSpeed(endGoalPosPoint.getSpeed());
                 }
-                updateControl(mCurrentState.currentGoal);
+                trol(mCurrentState.currentGoal);
             }
         }
     } break;
@@ -375,9 +397,19 @@ void PurepursuitWaypointFollower::updateState()
 
 void PurepursuitWaypointFollower::updateControl(const PosPoint &goal)
 {
+    PosPoint currentPos = mVehicleState->getPosition(mPosTypeUsed);   // ENU position
+    double cappedSpeed = goal.getSpeed();   // the goal's desired speed
+
+    // Check each speed limit region (if inside overlapping regions, the most restrictive limit will be applied)
+    for (const SpeedLimitRegion &region : mSpeedLimitRegions) {
+        if (ZigZagRouteGenerator::isPointWithin(currentPos, region.boundary)) {
+            cappedSpeed = std::min(cappedSpeed, region.maxSpeed);
+        }
+    }
+
     if (isOnVehicle()) {
         mMovementController->setDesiredSteeringCurvature(mVehicleState->getCurvatureToPointInENU(goal.getPoint(), mPosTypeUsed));
-        mMovementController->setDesiredSpeed(goal.getSpeed());
+        mMovementController->setDesiredSpeed(cappedSpeed);
         mMovementController->setDesiredAttributes(goal.getAttributes());
 
         mVehicleState->setAutopilotTargetPoint(goal.getPoint());
@@ -387,7 +419,7 @@ void PurepursuitWaypointFollower::updateControl(const PosPoint &goal)
                                     goal.getY() - mVehicleConnection->getVehicleState()->getPosition(mPosTypeUsed).getY(),
                                     mCurrentState.overrideAltitude - mVehicleState->getPosition(mPosTypeUsed).getHeight()};
         double positionDiffDistance = sqrtf(positionDifference.x*positionDifference.x + positionDifference.y*positionDifference.y + positionDifference.z*positionDifference.z);
-        double velocityFactor = goal.getSpeed() / positionDiffDistance;
+        double velocityFactor = cappedSpeed / positionDiffDistance;
 
         double yawDeg = atan2(goal.getY() - mVehicleState->getPosition(mPosTypeUsed).getY(),
                               goal.getX() - mVehicleState->getPosition(mPosTypeUsed).getX()) * 180.0 / M_PI;
@@ -522,5 +554,154 @@ QSharedPointer<VehicleState> PurepursuitWaypointFollower::getReferenceVehicleSta
         return mVehicleState->getTrailingVehicle();
     } else {
         return mVehicleState;
+    }
+}
+
+void PurepursuitWaypointFollower::addSpeedLimitRegion(const QList<PosPoint>& boundary, double maxSpeed_kmph)
+{
+    if (boundary.size() < 3) {
+        qDebug() << "WARNING: Speed limit region requires at least 3 points to define a polygon.";
+        return;
+    }
+
+    double maxSpeed_ms = maxSpeed_kmph / 3.6;  // convert km/h to m/s
+
+    SpeedLimitRegion region;
+    region.boundary = boundary;
+    region.maxSpeed = maxSpeed_ms;
+    mSpeedLimitRegions.append(region);
+
+    qInfo() << "Added speed limit region with" << boundary.size() << "vertices and max speed" << maxSpeed_kmph << "km/h. Keep in mind, any potential inner regions or holes are ignored";
+}
+
+void PurepursuitWaypointFollower::clearSpeedLimitRegions()
+{
+    mSpeedLimitRegions.clear();
+    qDebug() << "Cleared all speed limit regions";
+}
+
+QList<SpeedLimitRegion> PurepursuitWaypointFollower::getSpeedLimitRegions() const
+{
+    return mSpeedLimitRegions;
+}
+
+void PurepursuitWaypointFollower::loadSpeedLimitRegionsFile()
+{
+    QDir documentsDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));   // OS agnostic
+
+    QString folderName = "WayWise Speed Limits";
+    QString folderPath = documentsDirectory.filePath(folderName);
+
+    if (!documentsDirectory.exists(folderPath)) {
+        if (documentsDirectory.mkpath(folderPath)) {
+            qInfo() << "Speed limits folder created";
+        } else {
+            qWarning() << "Failed to create speed limits folder";
+            return;
+        }
+    }
+
+    QString fileName = "speedLimitRegions.json";
+    QString filePath = documentsDirectory.filePath(folderName + "/" + fileName);
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qInfo() << "Could not open speed limit regions file:" << filePath << Qt::endl
+                << "To create speed limit regions:" << Qt::endl
+                << "1. Go to https://geojson.io/#map=2/0/20 to easily define Polygons geometry" << Qt::endl
+                << "2. Copy the JSON source (make sure type is 'FeatureCollection')" << Qt::endl
+                << "3. Store as \"speedLimitRegions.json\" in the Documents/WayWise Speed Limits folder"  << Qt::endl
+                << "4. Add 'maxSpeed' in the 'properties' field (for example 'maxSpeed: 30.0') to set the speed limit (km/h) for a region";
+        return;
+    }
+
+    QJsonParseError parseError;
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(file.readAll(), &parseError);
+    file.close();
+
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "JSON parse error:" << parseError.errorString();
+        return;
+    }
+
+    if (!jsonDoc.isObject()) {
+        qWarning() << "Invalid JSON: root must be an object";
+        return;
+    }
+
+    parseSpeedLimitRegionsDocument(jsonDoc);
+}
+
+void PurepursuitWaypointFollower::parseSpeedLimitRegionsDocument(const QJsonDocument& jsonDoc)
+{
+    QJsonObject root = jsonDoc.object();
+
+    // Validate file is a WGS‑84 GeoJSON (standard per RFC 7946)
+    if (root["type"].toString() != "FeatureCollection") {
+        qWarning() << "Invalid GeoJSON: type must be FeatureCollection";
+        return;
+    }
+
+    QJsonArray features = root["features"].toArray();
+
+    for (const QJsonValue& featureValue : features) {
+
+        QJsonObject feature = featureValue.toObject();
+
+        // --- properties ---
+        double maxSpeed_kmph = feature["properties"].toObject()["maxSpeed"].toDouble(std::numeric_limits<double>::quiet_NaN()); // returns NaN if conversion fails
+        if (!std::isfinite(maxSpeed_kmph) || maxSpeed_kmph < 0.0) {
+            qWarning() << "Skipping feature: invalid 'maxSpeed' value";
+            continue;
+        }
+
+        // --- geometry ---
+        QJsonObject geometry = feature["geometry"].toObject();
+        if (geometry["type"].toString() != "Polygon") {
+            qWarning() << "Skipping non-Polygon geometry (only polygons are supported, not MultiPolygon, LineString, etc.)";
+            continue;
+        }
+
+        // GeoJSON Polygon coordinates are [[[lon, lat], [lon, lat], ...]]
+        QJsonArray coordinates = geometry["coordinates"].toArray();
+        if (coordinates.isEmpty() || !coordinates[0].isArray()) {
+            qWarning() << "Skipping empty coordinates";
+            continue;
+        }
+
+        // Get the outer ring (first array)
+        QJsonArray outerRing = coordinates[0].toArray();
+
+        llh_t enuRef = mVehicleState->getEnuRef();
+        QList<PosPoint> boundary;
+        for (const QJsonValue& coordValue : outerRing) {
+            QJsonArray coord = coordValue.toArray();
+            if (coord.size() < 2) {
+                qWarning() << "Skipping invalid coordinates";
+                continue;
+            }
+
+            // GeoJSON uses [longitude, latitude] order
+            double longitude = coord[0].toDouble();
+            double latitude = coord[1].toDouble();
+            double altitude = coord.size() > 2 ? coord[2].toDouble() : 0.0; // use 0 if altitude is absent
+
+            // latitude/longitude range checks
+            if (latitude < -90.0 || latitude > 90.0 || longitude < -180.0 || longitude > 180.0) continue;
+
+            // Convert lat/lon to ENU coordinates
+            llh_t llh{latitude, longitude, altitude};
+            xyz_t enu = coordinateTransforms::llhToEnu(enuRef, llh);
+
+            PosPoint point;
+            point.setX(enu.x);
+            point.setY(enu.y);
+            point.setHeight(enu.z);
+            boundary.append(point);
+        }
+
+        if (!boundary.isEmpty()) {
+            addSpeedLimitRegion(boundary, maxSpeed_kmph);
+        }
     }
 }

--- a/autopilot/purepursuitwaypointfollower.cpp
+++ b/autopilot/purepursuitwaypointfollower.cpp
@@ -227,7 +227,7 @@ void PurepursuitWaypointFollower::updateState()
 
         if (intersections.size()) {
             mCurrentState.currentGoal.setXY(intersections[0].x(), intersections[0].y());
-            trol(mCurrentState.currentGoal);
+            updateControl(mCurrentState.currentGoal);
         } else { // first waypoint within circle -> start route
             if (mWaypointList.size() > 1) {
                 mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
@@ -319,7 +319,7 @@ void PurepursuitWaypointFollower::updateState()
             mCurrentState.currentGoal.setAttributes(closestWaypoint.getAttributes());
 
             // 4. Update control for current goal
-            trol(mCurrentState.currentGoal);
+            updateControl(mCurrentState.currentGoal);
         }
     } break;
     case WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL: {
@@ -379,7 +379,7 @@ void PurepursuitWaypointFollower::updateState()
                 } else {
                     mCurrentState.currentGoal.setSpeed(endGoalPosPoint.getSpeed());
                 }
-                trol(mCurrentState.currentGoal);
+                updateControl(mCurrentState.currentGoal);
             }
         }
     } break;

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -33,6 +33,11 @@ struct WayPointFollowerState {
     double overrideAltitude = 0.0;
 };
 
+struct SpeedLimitRegion {
+    QList<PosPoint> boundary;  // 2D-Polygon vertices (altitude not considered). If first point != last point, the polygon will automatically be closed by connecting the last vertex back to the first vertex
+    double maxSpeed;           // Speed limit [m/s]
+};
+
 class PurepursuitWaypointFollower : public WaypointFollower
 {
     Q_OBJECT
@@ -84,6 +89,12 @@ public:
     void setAdaptiveApproachSpeedEnabled(bool adaptive) {mAdaptiveApproachSpeedEnabled = adaptive;}
     void setMinApproachSpeed(double minApproachSpeed) {mMinApproachSpeed = minApproachSpeed;}
 
+    void loadSpeedLimitRegionsFile();
+    void parseSpeedLimitRegionsDocument(const QJsonDocument& jsonDoc);
+    void addSpeedLimitRegion(const QList<PosPoint>& boundary, double maxSpeed_kmph);
+    void clearSpeedLimitRegions();
+    QList<SpeedLimitRegion> getSpeedLimitRegions() const;
+
 signals:
     void distanceOfRouteLeft(double meters);
 
@@ -94,6 +105,7 @@ private:
     QPointF getVehicleReferencePosition(const QList<PosPoint>& waypoints);
 
     WayPointFollowerState mCurrentState;
+    QList<SpeedLimitRegion> mSpeedLimitRegions;
 
     PosType mPosTypeUsed = PosType::fused; // The type of position (Odom, GNSS, UWB, ...) that should be used for planning
     QSharedPointer<MovementController> mMovementController;

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -94,7 +94,8 @@ public:
     void addSpeedLimitRegion(const QList<PosPoint>& boundary, double maxSpeed_kmph);
     void clearSpeedLimitRegions();
     QList<SpeedLimitRegion> getSpeedLimitRegions() const;
-
+void setSpeedLimitRegionsFilePath(QString value) { mSpeedLimitRegionsFilePath = value;};
+QString getSpeedLimitRegionsFilePath() const {return mSpeedLimitRegionsFilePath;};
 signals:
     void distanceOfRouteLeft(double meters);
 
@@ -106,7 +107,7 @@ private:
 
     WayPointFollowerState mCurrentState;
     QList<SpeedLimitRegion> mSpeedLimitRegions;
-
+QString mSpeedLimitRegionsFilePath;
     PosType mPosTypeUsed = PosType::fused; // The type of position (Odom, GNSS, UWB, ...) that should be used for planning
     QSharedPointer<MovementController> mMovementController;
     QSharedPointer<VehicleConnection> mVehicleConnection;

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -107,7 +107,7 @@ private:
 
     WayPointFollowerState mCurrentState;
     QList<SpeedLimitRegion> mSpeedLimitRegions;
-QString mSpeedLimitRegionsFilePath;
+    QString mSpeedLimitRegionsFilePath = "No file path specified";
     PosType mPosTypeUsed = PosType::fused; // The type of position (Odom, GNSS, UWB, ...) that should be used for planning
     QSharedPointer<MovementController> mMovementController;
     QSharedPointer<VehicleConnection> mVehicleConnection;

--- a/autopilot/purepursuitwaypointfollower.h
+++ b/autopilot/purepursuitwaypointfollower.h
@@ -89,13 +89,12 @@ public:
     void setAdaptiveApproachSpeedEnabled(bool adaptive) {mAdaptiveApproachSpeedEnabled = adaptive;}
     void setMinApproachSpeed(double minApproachSpeed) {mMinApproachSpeed = minApproachSpeed;}
 
-    void loadSpeedLimitRegionsFile();
+    void loadSpeedLimitRegionsFile(const QString& filePath);
     void parseSpeedLimitRegionsDocument(const QJsonDocument& jsonDoc);
     void addSpeedLimitRegion(const QList<PosPoint>& boundary, double maxSpeed_kmph);
     void clearSpeedLimitRegions();
     QList<SpeedLimitRegion> getSpeedLimitRegions() const;
-void setSpeedLimitRegionsFilePath(QString value) { mSpeedLimitRegionsFilePath = value;};
-QString getSpeedLimitRegionsFilePath() const {return mSpeedLimitRegionsFilePath;};
+
 signals:
     void distanceOfRouteLeft(double meters);
 
@@ -107,7 +106,6 @@ private:
 
     WayPointFollowerState mCurrentState;
     QList<SpeedLimitRegion> mSpeedLimitRegions;
-    QString mSpeedLimitRegionsFilePath = "No file path specified";
     PosType mPosTypeUsed = PosType::fused; // The type of position (Odom, GNSS, UWB, ...) that should be used for planning
     QSharedPointer<MovementController> mMovementController;
     QSharedPointer<VehicleConnection> mVehicleConnection;

--- a/communication/iso22133vehicleserver.cpp
+++ b/communication/iso22133vehicleserver.cpp
@@ -162,7 +162,7 @@ void iso22133VehicleServer::onOSEM(ObjectSettingsType &osem) {
     const llh_t llh = {osem.coordinateSystemOrigin.latitude_deg, osem.coordinateSystemOrigin.longitude_deg, osem.coordinateSystemOrigin.altitude_m};
     if (!mGNSSReceiver.isNull())
     {
-        mGNSSReceiver->setEnuRef(llh);
+        mVehicleState->setEnuRef(llh);
     } else {
         qWarning() << "No UbloxRover set to receive llh!!";
     }

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -65,12 +65,12 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
 
         if (!mGNSSReceiver.isNull()) {
             // publish gpsOrigin
-            sendGpsOriginLlh(mGNSSReceiver->getEnuRef());
+            sendGpsOriginLlh(mVehicleState->getEnuRef());
 
             //TODO: homePositionLlh should not be EnuRef
-            homePositionLlh = {mGNSSReceiver->getEnuRef().latitude, mGNSSReceiver->getEnuRef().longitude, static_cast<float>(mGNSSReceiver->getEnuRef().height), 0};
+            homePositionLlh = {mVehicleState->getEnuRef().latitude, mVehicleState->getEnuRef().longitude, static_cast<float>(mVehicleState->getEnuRef().height), 0};
 
-            llh_t fusedPosGlobal = coordinateTransforms::enuToLlh(mGNSSReceiver->getEnuRef(), {mVehicleState->getPosition(PosType::fused).getXYZ()});
+            llh_t fusedPosGlobal = coordinateTransforms::enuToLlh(mVehicleState->getEnuRef(), {mVehicleState->getPosition(PosType::fused).getXYZ()});
             positionLlh = {fusedPosGlobal.latitude, fusedPosGlobal.longitude, static_cast<float>(fusedPosGlobal.height), 0};
         }
 

--- a/examples/RCCar_ISO22133_autopilot/CMakeLists.txt
+++ b/examples/RCCar_ISO22133_autopilot/CMakeLists.txt
@@ -50,6 +50,8 @@ add_executable(RCCar_ISO22133_autopilot
     ${WAYWISE_PATH}/communication/vehicleserver.h
     ${WAYWISE_PATH}/communication/iso22133vehicleserver.cpp
     ${WAYWISE_PATH}/logger/logger.cpp
+    ${WAYWISE_PATH}/routeplanning/zigzagroutegenerator.cpp
+    ${WAYWISE_PATH}/routeplanning/zigzagroutegenerator.h
 )
 
 target_include_directories(RCCar_ISO22133_autopilot PRIVATE ${WAYWISE_PATH})

--- a/examples/RCCar_MAVLINK_autopilot/CMakeLists.txt
+++ b/examples/RCCar_MAVLINK_autopilot/CMakeLists.txt
@@ -49,6 +49,8 @@ add_executable(RCCar_MAVLINK_autopilot
     ${WAYWISE_PATH}/communication/vehicleserver.h
     ${WAYWISE_PATH}/communication/mavsdkvehicleserver.cpp
     ${WAYWISE_PATH}/logger/logger.cpp
+    ${WAYWISE_PATH}/routeplanning/zigzagroutegenerator.cpp
+    ${WAYWISE_PATH}/routeplanning/zigzagroutegenerator.h
 )
 
 target_include_directories(RCCar_MAVLINK_autopilot PRIVATE ${WAYWISE_PATH})

--- a/examples/map_local_twocars/CMakeLists.txt
+++ b/examples/map_local_twocars/CMakeLists.txt
@@ -46,6 +46,8 @@ add_executable(map_local_twocars
     ${WAYWISE_PATH}/vehicles/controller/motorcontroller.h
     ${WAYWISE_PATH}/vehicles/controller/movementcontroller.cpp
     ${WAYWISE_PATH}/vehicles/controller/servocontroller.cpp
+    ${WAYWISE_PATH}/routeplanning/zigzagroutegenerator.cpp
+    ${WAYWISE_PATH}/routeplanning/zigzagroutegenerator.h
 )
 
 target_include_directories(map_local_twocars PRIVATE ${WAYWISE_PATH}/)

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -10,12 +10,4 @@
 GNSSReceiver::GNSSReceiver(QSharedPointer<VehicleState> vehicleState)
 {
     mVehicleState = vehicleState;
-    mEnuReference = {57.71495867, 12.89134921, 0}; // AztaZero {57.7810, 12.7692, 0}, Klätterlabbet {57.6876, 11.9807, 0}, RISE RTK base station {57.71495867, 12.89134921, 0}
-}
-
-void GNSSReceiver::setEnuRef(llh_t enuRef)
-{
-    mEnuReference = enuRef;
-    mEnuReferenceSet = true;
-    emit updatedEnuReference(mEnuReference);
 }

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -49,8 +49,6 @@ public:
 
     void setReceiverVariant(RECEIVER_VARIANT receiverVariant) { mReceiverVariant = receiverVariant; }
     RECEIVER_VARIANT getReceiverVariant() { return mReceiverVariant; }
-    virtual llh_t getEnuRef() const { return mEnuReference; }
-    virtual void setEnuRef(llh_t enuRef);
     virtual void setChipOrientationOffset(double roll_deg, double pitch_deg, double yaw_deg) { mAChipOrientationOffset = {roll_deg, pitch_deg, yaw_deg}; }
     virtual void setAntennaToChipOffset(double xOffset, double yOffset, double zOffset) { mAntennaToChipOffset = {xOffset, yOffset, zOffset}; }
     virtual void setChipToRearAxleOffset(double xOffset, double yOffset, double zOffset) { mChipToRearAxleOffset = {xOffset, yOffset, zOffset}; }
@@ -61,9 +59,6 @@ public:
     virtual void setGnssFixAccuracy(GnssFixAccuracy gnssFixAccuracy) { mGnssFixAccuracy = gnssFixAccuracy; }
     virtual GnssFixAccuracy getGnssFixAccuracy() { return mGnssFixAccuracy; }
 
-signals:
-    void updatedEnuReference(llh_t mEnuReference);
-
 protected:
     virtual void shutdownGNSSReceiver() {};
 
@@ -71,8 +66,6 @@ protected:
     RECEIVER_STATE mReceiverState = RECEIVER_STATE::UNKNOWN;
     GNSS_FIX_TYPE mFixType = GNSS_FIX_TYPE::NO_FIX;
 
-    llh_t mEnuReference;
-    bool mEnuReferenceSet = false;
     QSharedPointer<VehicleState> mVehicleState;
     struct {double rollOffset_deg, pitchOffset_deg, yawOffset_deg;} mAChipOrientationOffset; // in degrees
     xyz_t mAntennaToChipOffset = {0.0, 0.0, 0.0}; // in meters

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -355,11 +355,11 @@ void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
         llh_t llh = {pvt.lat, pvt.lon, pvt.height};
         xyz_t xyz = {0.0, 0.0, 0.0};
 
-        if (!mEnuReferenceSet) {
-            setEnuRef(llh);
+        if (!mVehicleState->isEnuReferenceSet()) {
+            mVehicleState->setEnuRef(llh);
             qDebug() << "UbloxRover: ENU reference point set to" << pvt.lat << pvt.lon << pvt.height;
         } else
-            xyz = coordinateTransforms::llhToEnu(mEnuReference, llh);
+            xyz = coordinateTransforms::llhToEnu(mVehicleState->getEnuRef(), llh);
 
         // Position
         gnssPos.setXYZ(xyz);

--- a/vehicles/vehiclestate.cpp
+++ b/vehicles/vehiclestate.cpp
@@ -146,3 +146,15 @@ bool VehicleState::hasTrailingVehicle() const
 {
     return !mTrailingVehicle.isNull();
 }
+
+void VehicleState::setEnuRef(llh_t enuRef)
+{
+    mEnuReference = enuRef;
+    mEnuReferenceSet = true;
+    emit updatedEnuReference(mEnuReference);
+}
+
+bool VehicleState::isEnuReferenceSet()
+{
+    return mEnuReferenceSet;
+}

--- a/vehicles/vehiclestate.h
+++ b/vehicles/vehiclestate.h
@@ -57,6 +57,10 @@ public:
     double getMaxAcceleration() const { return mMaxAcceleration; }
     void setMaxAcceleration(double maxAcceleration) { mMaxAcceleration = maxAcceleration; }
 
+    virtual llh_t getEnuRef() const { return mEnuReference; }
+    virtual void setEnuRef(llh_t enuRef);
+    bool isEnuReferenceSet();
+
     xyz_t getRearAxleToCenterOffset() const { return mRearAxleToCenterOffset; }
     void setRearAxleToCenterOffset(double rearAxleToCenterOffsetX) { mRearAxleToCenterOffset.x = rearAxleToCenterOffsetX; }
     void setRearAxleToCenterOffset(xyz_t rearAxleToCenterOffset) { mRearAxleToCenterOffset = rearAxleToCenterOffset; }
@@ -107,6 +111,8 @@ public:
     std::array<float, 3> getAccelerometerXYZ() const;
     void setAccelerometerXYZ(const std::array<float, 3> &accelerometerXYZ);
 
+signals:
+    void updatedEnuReference(llh_t mEnuReference);
 
 private:
     // Static state
@@ -119,6 +125,9 @@ private:
     xyz_t mRearAxleToCenterOffset;
     xyz_t mRearAxleToRearEndOffset{-0.1333, 0.0, 0.0};
     xyz_t mRearAxleToHitchOffset;
+
+    llh_t mEnuReference = {57.71495867, 12.89134921, 0}; // AztaZero {57.7810, 12.7692, 0}, Klätterlabbet {57.6876, 11.9807, 0}, RISE RTK base station {57.71495867, 12.89134921, 0}
+    bool mEnuReferenceSet = false;
 
     // Dynamic state
     double mSteering = 0.0; // [-1.0:1.0]


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Support for loading regions (polygons) with speed limited from JSON file.

* **What is the current behavior?** (You can also link to an open issue here)

There is currently no support for speed limited regions, however there is a custom polygon implementation: ZigZagRouteGenerator::isPointWithin() which has been utilised for this pull request.

* **What is the new behavior (if this is a feature change)?**

If the vehicle's position is inside any of the regions defined by the JSON file, it will adhere to its speed limit. If it is within multiple overlapping region, it will adhere to the lowest speed limit.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Adjustments need to be made in RCCar's main file, I will open another pull request there.

* **Other information**:

ENU reference is now accessed from VehicleState instead of GNSSReceiver.