### PR TITLE
Refactor GNSS architecture: Allow creating GnssReceiver with ObjectState

### DIFF
--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -63,16 +63,14 @@ MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleSta
         mavsdk::TelemetryServer::Position homePositionLlh{};
         mavsdk::TelemetryServer::Position positionLlh{};
 
-        if (!mGNSSReceiver.isNull()) {
-            // publish gpsOrigin
-            sendGpsOriginLlh(mVehicleState->getEnuRef());
+        // publish gpsOrigin
+        sendGpsOriginLlh(mVehicleState->getEnuRef());
 
-            //TODO: homePositionLlh should not be EnuRef
-            homePositionLlh = {mVehicleState->getEnuRef().latitude, mVehicleState->getEnuRef().longitude, static_cast<float>(mVehicleState->getEnuRef().height), 0};
+        //TODO: homePositionLlh should not be EnuRef
+        homePositionLlh = {mVehicleState->getEnuRef().latitude, mVehicleState->getEnuRef().longitude, static_cast<float>(mVehicleState->getEnuRef().height), 0};
 
-            llh_t fusedPosGlobal = coordinateTransforms::enuToLlh(mVehicleState->getEnuRef(), {mVehicleState->getPosition(PosType::fused).getXYZ()});
-            positionLlh = {fusedPosGlobal.latitude, fusedPosGlobal.longitude, static_cast<float>(fusedPosGlobal.height), 0};
-        }
+        llh_t fusedPosGlobal = coordinateTransforms::enuToLlh(mVehicleState->getEnuRef(), {mVehicleState->getPosition(PosType::fused).getXYZ()});
+        positionLlh = {fusedPosGlobal.latitude, fusedPosGlobal.longitude, static_cast<float>(fusedPosGlobal.height), 0};
 
         mTelemetryServer->publish_position(positionLlh, velocity, heading);
         mTelemetryServer->publish_home(homePositionLlh);

--- a/communication/mavsdkvehicleserver.cpp
+++ b/communication/mavsdkvehicleserver.cpp
@@ -15,8 +15,7 @@
 MavsdkVehicleServer::MavsdkVehicleServer(QSharedPointer<VehicleState> vehicleState, const QHostAddress controlTowerAddress, const unsigned controlTowerPort, const QAbstractSocket::SocketType controlTowerSocketType) :
     VehicleServer(vehicleState)
 {
-    connect(&Logger::getInstance(), &Logger::logSent, this, &MavsdkVehicleServer::on_logSent);
-
+    setTransferLogs(true);
     mVehicleState = vehicleState;
     mSystemId = mVehicleState->getId();
 
@@ -731,6 +730,16 @@ void MavsdkVehicleServer::on_logSent(const QString& message, const quint8& sever
     }
 
     logQueue.clear();
+}
+
+void MavsdkVehicleServer::setTransferLogs(bool transferLogs)
+{
+    if (transferLogs && !mTransferLogs) {
+        connect(&Logger::getInstance(), &Logger::logSent, this, &MavsdkVehicleServer::on_logSent);
+    } else if (!transferLogs && mTransferLogs) {
+        disconnect(&Logger::getInstance(), &Logger::logSent, this, &MavsdkVehicleServer::on_logSent);
+    }
+    mTransferLogs = transferLogs;
 }
 
 void MavsdkVehicleServer::sendMissionAck(quint8 type)

--- a/communication/mavsdkvehicleserver.h
+++ b/communication/mavsdkvehicleserver.h
@@ -38,6 +38,7 @@ public:
     void on_logSent(const QString& message, const quint8& severity);
     void updateRawGpsAndGpsInfoFromUbx(const ubx_nav_pvt &pvt) override;
     void setMavsdkRawGpsAndGpsInfo(const mavsdk::TelemetryServer::RawGps &rawGps, const mavsdk::TelemetryServer::GpsInfo &gpsInfo);
+    void setTransferLogs(bool transferLogs);
 
     void provideParametersToParameterServer();
 
@@ -55,6 +56,7 @@ private:
 
     QDateTime mMavsdkVehicleServerCreationTime = QDateTime::currentDateTime();
     ParameterServer *mParameterServer;
+    bool mTransferLogs = false;
 
     const unsigned mCountdown_ms = 2000;
 

--- a/core/coordinatetransforms.h
+++ b/core/coordinatetransforms.h
@@ -17,6 +17,12 @@ struct llh_t {
     double height;
 };
 
+struct rpy_t {
+    double roll;
+    double pitch;
+    double yaw;
+};
+
 struct xyz_t {
     double x;
     double y;
@@ -56,6 +62,14 @@ struct xyz_t {
     xyz_t operator-() const {
         return {-x, -y, -z};
     }
+
+    double dist(const xyz_t & other) const
+    {
+        double dx = x - other.x;
+        double dy = y - other.y;
+        double dz = z - other.z;
+        return std::sqrt(dx * dx + dy * dy + dz * dz);
+  }
 };
 
 namespace coordinateTransforms {

--- a/core/pospoint.cpp
+++ b/core/pospoint.cpp
@@ -49,6 +49,11 @@ double PosPoint::getPitch() const
     return mPitch;
 }
 
+rpy_t PosPoint::getRPY() const
+{
+    return {mRoll, mPitch, mYaw};
+}
+
 double PosPoint::getYaw() const
 {
     return mYaw;
@@ -237,6 +242,13 @@ void PosPoint::setRollPitchYaw(double roll, double pitch, double yaw)
     mRoll = roll;
     mPitch = pitch;
     mYaw = yaw;
+}
+
+void PosPoint::setRPY(rpy_t rpy)
+{
+    mRoll = rpy.roll;
+    mPitch = rpy.pitch;
+    mYaw = rpy.yaw;
 }
 
 void PosPoint::setSpeed(double speed)

--- a/core/pospoint.h
+++ b/core/pospoint.h
@@ -41,6 +41,7 @@ public:
     double getRoll() const;
     double getPitch() const;
     double getYaw() const;
+    rpy_t getRPY() const;
     double getSpeed() const;
     QPointF getPoint() const;
     QPointF getPointMm() const;
@@ -66,6 +67,7 @@ public:
     void setPitch(double pitch);
     void setYaw(double alpha);
     void setRollPitchYaw(double roll, double pitch, double yaw);
+    void setRPY(rpy_t rpy);
     void setSpeed(double speed);
     void setRadius(double radius);
     void setSigma(double sigma);
@@ -76,7 +78,7 @@ public:
     void setDrawLine(bool drawLine);
     void setAttributes(quint32 attributes);
 
-    void updateWithOffsetAndYawRotation (xyz_t offset, double yaw);
+    void updateWithOffsetAndYawRotation (xyz_t offset, double yaw_rad);
 
     // Operators
     PosPoint& operator=(const PosPoint& point);

--- a/sensors/fusion/sdvpvehiclepositionfuser.cpp
+++ b/sensors/fusion/sdvpvehiclepositionfuser.cpp
@@ -60,9 +60,9 @@ double SDVPVehiclePositionFuser::getMaxSignedStepFromValueTowardsGoal(double val
     return goal - value;
 }
 
-void SDVPVehiclePositionFuser::correctPositionAndYawGNSS(QSharedPointer<ObjectState> objectState, double distanceMoved, bool fused)
+void SDVPVehiclePositionFuser::correctPositionAndYawGNSS(QSharedPointer<ObjectState> objectState, double distanceMoved, GnssFixStatus gnssFixStatus)
 {
-    mPosGNSSisFused = fused;
+    mPosGNSSisFused = gnssFixStatus.isFusedOnChip;
     PosPoint posGNSS = objectState->getPosition(PosType::GNSS);
     PosPoint posIMU = objectState->getPosition(PosType::IMU);
     PosPoint posFused = objectState->getPosition(PosType::fused);

--- a/sensors/fusion/sdvpvehiclepositionfuser.h
+++ b/sensors/fusion/sdvpvehiclepositionfuser.h
@@ -28,9 +28,9 @@ class SDVPVehiclePositionFuser : public QObject
     Q_OBJECT
 public:
     explicit SDVPVehiclePositionFuser(QObject *parent = nullptr);
-    void correctPositionAndYawGNSS(QSharedPointer<VehicleState> vehicleState, double distanceMoved, bool fused);
-    void correctPositionAndYawOdom(QSharedPointer<VehicleState> vehicleState, double distanceDriven);
-    void correctPositionAndYawIMU(QSharedPointer<VehicleState> vehicleState);
+    void correctPositionAndYawGNSS(QSharedPointer<ObjectState> objectState, double distanceMoved, bool fused);
+    void correctPositionAndYawOdom(QSharedPointer<ObjectState> objectState, double distanceDriven);
+    void correctPositionAndYawIMU(QSharedPointer<ObjectState> objectState);
 
     void setPosGNSSxyStaticGain(double posGNSSxyStaticGain);
     void setPosGNSSyawGain(double posGNSSyawGain);

--- a/sensors/fusion/sdvpvehiclepositionfuser.h
+++ b/sensors/fusion/sdvpvehiclepositionfuser.h
@@ -22,13 +22,14 @@
 #include <QObject>
 #include <QSharedPointer>
 #include "vehicles/vehiclestate.h"
+#include "sensors/gnss/gnssreceiver.h"
 
 class SDVPVehiclePositionFuser : public QObject
 {
     Q_OBJECT
 public:
     explicit SDVPVehiclePositionFuser(QObject *parent = nullptr);
-    void correctPositionAndYawGNSS(QSharedPointer<ObjectState> objectState, double distanceMoved, bool fused);
+    void correctPositionAndYawGNSS(QSharedPointer<ObjectState> objectState, double distanceMoved, GnssFixStatus gnssFixStatus);
     void correctPositionAndYawOdom(QSharedPointer<ObjectState> objectState, double distanceDriven);
     void correctPositionAndYawIMU(QSharedPointer<ObjectState> objectState);
 

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -7,9 +7,9 @@
 
 #include "gnssreceiver.h"
 
-GNSSReceiver::GNSSReceiver(QSharedPointer<VehicleState> vehicleState)
+GNSSReceiver::GNSSReceiver(QSharedPointer<ObjectState> objectState)
 {
-    mVehicleState = vehicleState;
+    mObjectState = objectState;
 }
 
 bool GNSSReceiver::simulationStep(const std::function<bool(QTime, QSharedPointer<VehicleState>)> &perturbationFn)

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -12,34 +12,35 @@ GNSSReceiver::GNSSReceiver(QSharedPointer<ObjectState> objectState)
     mObjectState = objectState;
 }
 
-void GNSSReceiver::simulationStep(const std::function<GnssFixStatus(QTime, QSharedPointer<ObjectState>)> &perturbationFn)
+void GNSSReceiver::simulationStep(const std::function<GnssFixStatus(QTime, QSharedPointer<ObjectState>)> &simulationFn)
 {
-    static QPointF lastGNSSPoint = QPointF();
-    static PosPoint lastOdomPosPoint = PosPoint();
+    static xyz_t lastGNSS_xyz;
     PosPoint gnssPosPoint = mObjectState->getPosition(PosType::GNSS);
     PosPoint odomPosPoint = mObjectState->getPosition(PosType::odom);
 
-    double deltaX = odomPosPoint.getX() - lastOdomPosPoint.getX();
-    double deltaY = odomPosPoint.getY() - lastOdomPosPoint.getY();
-    double deltaYaw = odomPosPoint.getYaw() - lastOdomPosPoint.getYaw();
-    gnssPosPoint.setX(gnssPosPoint.getX() + deltaX);
-    gnssPosPoint.setY(gnssPosPoint.getY() + deltaY);
-    double yawResult = gnssPosPoint.getYaw() + deltaYaw;
-
-    while (yawResult < -180.0)
-        yawResult += 360.0;
-    while (yawResult >= 180.0)
-        yawResult -= 360.0;
-
-    gnssPosPoint.setYaw(yawResult);
-    gnssPosPoint.setTime(odomPosPoint.getTime());
-    mObjectState->setPosition(gnssPosPoint);
-
     GnssFixStatus gnssFixStatus;
-    if (perturbationFn) {
-        gnssFixStatus = perturbationFn(odomPosPoint.getTime(), mObjectState);
+    if (simulationFn) {
+        gnssFixStatus = simulationFn(odomPosPoint.getTime(), mObjectState);
         gnssPosPoint = mObjectState->getPosition(PosType::GNSS);
     } else {
+        static PosPoint lastOdomPosPoint = PosPoint();
+
+        double deltaX = odomPosPoint.getX() - lastOdomPosPoint.getX();
+        double deltaY = odomPosPoint.getY() - lastOdomPosPoint.getY();
+        double deltaYaw = odomPosPoint.getYaw() - lastOdomPosPoint.getYaw();
+        gnssPosPoint.setX(gnssPosPoint.getX() + deltaX);
+        gnssPosPoint.setY(gnssPosPoint.getY() + deltaY);
+        double yawResult = gnssPosPoint.getYaw() + deltaYaw;
+
+        while (yawResult < -180.0)
+            yawResult += 360.0;
+        while (yawResult >= 180.0)
+            yawResult -= 360.0;
+
+        gnssPosPoint.setYaw(yawResult);
+        gnssPosPoint.setTime(odomPosPoint.getTime());
+        mObjectState->setPosition(gnssPosPoint);
+
         gnssFixStatus.isFusedOnChip = true;
         gnssFixStatus.fixType = GNSS_FIX_TYPE::FIX_3D;
         gnssFixStatus.horizontalAccuracy = 0.0;
@@ -47,14 +48,15 @@ void GNSSReceiver::simulationStep(const std::function<GnssFixStatus(QTime, QShar
         gnssFixStatus.headingAccuracy = 0.0;
         gnssFixStatus.lastRtcmCorrectionAge = 0;
         gnssFixStatus.numSatellites = 0;
+
+        lastOdomPosPoint = odomPosPoint;
     }
 
-    emit updatedGNSSPositionAndYaw(mObjectState, QLineF(lastGNSSPoint, gnssPosPoint.getPoint()).length(), gnssFixStatus);
-    lastGNSSPoint = gnssPosPoint.getPoint();
-    lastOdomPosPoint = odomPosPoint;
+    emit updatedGNSSPositionAndOrientation(mObjectState, lastGNSS_xyz.dist(gnssPosPoint.getXYZ()), gnssFixStatus);
+    lastGNSS_xyz = gnssPosPoint.getXYZ();
 }
 
-void GNSSReceiver::updateGNSSPositionAndYaw(llh_t llh, double heading, bool isFusedOnChip)
+void GNSSReceiver::updateGNSSPositionAndOrientation(llh_t llh, rpy_t rpy_degNED, bool isFusedOnChip)
 {
 
     PosPoint gnssPos = mObjectState->getPosition(PosType::GNSS);
@@ -69,9 +71,8 @@ void GNSSReceiver::updateGNSSPositionAndYaw(llh_t llh, double heading, bool isFu
     // Position
     gnssPos.setXYZ(xyz);
 
-    double vehYaw_radENU = 0.0;
     if (isFusedOnChip) {
-        double yaw_degENU = coordinateTransforms::yawNEDtoENU(heading) + mAChipOrientationOffset.yawOffset_deg;
+        double yaw_degENU = coordinateTransforms::yawNEDtoENU(rpy_degNED.yaw) + mAChipOrientationOffset.yawOffset_deg;
 
         // normalize to [-180.0:180.0]
         while (yaw_degENU < -180.0)
@@ -81,21 +82,29 @@ void GNSSReceiver::updateGNSSPositionAndYaw(llh_t llh, double heading, bool isFu
 
         gnssPos.setYaw(yaw_degENU);
 
-        vehYaw_radENU = yaw_degENU * M_PI / 180.0;
-
         // Apply Chip to rear axle offset if set.
         if (mChipToBaseOffset.x != 0.0 || mChipToBaseOffset.y != 0.0) {
-            gnssPos.updateWithOffsetAndYawRotation(mChipToBaseOffset, vehYaw_radENU);
+            gnssPos.updateWithOffsetAndYawRotation(mChipToBaseOffset, yaw_degENU * M_PI / 180.0);
         }
+        gnssPos.setRoll(rpy_degNED.roll);
+        gnssPos.setPitch(-rpy_degNED.pitch); // NED to ENU
     } else { // Assumes fused yaw is updated.
         PosPoint fusedPos = mObjectState->getPosition(PosType::fused);
-        vehYaw_radENU = fusedPos.getYaw() * M_PI / 180.0;
+        rpy_t fusedPos_rpy_degENU = fusedPos.getRPY();
 
         // Apply antenna to rear axle offset if set.
         xyz_t mAntennaToRearAxleOffset = mAntennaToChipOffset + mChipToBaseOffset;
         if (mAntennaToRearAxleOffset.x != 0.0 || mAntennaToRearAxleOffset.y != 0.0) {
-            gnssPos.updateWithOffsetAndYawRotation(mAntennaToRearAxleOffset, vehYaw_radENU);
+            gnssPos.updateWithOffsetAndYawRotation(mAntennaToRearAxleOffset, fusedPos_rpy_degENU.yaw * M_PI / 180.0);
         }
+        gnssPos.setRoll(fusedPos_rpy_degENU.roll);
+        gnssPos.setPitch(fusedPos_rpy_degENU.pitch);
     }
     mObjectState->setPosition(gnssPos);
+}
+
+void GNSSReceiver::updateGNSSPositionAndOrientation(llh_t llh, double heading_degNED, bool isFusedOnChip)
+{
+    rpy_t rpy_degNED = {0.0, 0.0, heading_degNED};
+    updateGNSSPositionAndOrientation(llh, rpy_degNED, isFusedOnChip);
 }

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -12,33 +12,44 @@ GNSSReceiver::GNSSReceiver(QSharedPointer<ObjectState> objectState)
     mObjectState = objectState;
 }
 
-bool GNSSReceiver::simulationStep(const std::function<bool(QTime, QSharedPointer<VehicleState>)> &perturbationFn)
+void GNSSReceiver::simulationStep(const std::function<GnssFixStatus(QTime, QSharedPointer<ObjectState>)> &perturbationFn)
 {
-    static PosPoint prevOdomPosition = PosPoint();
-    PosPoint odomPosition = mVehicleState->getPosition(PosType::odom);
+    static QPointF lastGNSSPoint = QPointF();
+    static PosPoint lastOdomPosPoint = PosPoint();
+    PosPoint gnssPosPoint = mObjectState->getPosition(PosType::GNSS);
+    PosPoint odomPosPoint = mObjectState->getPosition(PosType::odom);
 
-    double deltaX = odomPosition.getX() - prevOdomPosition.getX();
-    double deltaY = odomPosition.getY() - prevOdomPosition.getY();
-    double deltaYaw = odomPosition.getYaw() - prevOdomPosition.getYaw();
-
-    PosPoint gnssPosition = mVehicleState->getPosition(PosType::GNSS);
-    gnssPosition.setX(gnssPosition.getX() + deltaX);
-    gnssPosition.setY(gnssPosition.getY() + deltaY);
-    double yawResult = gnssPosition.getYaw() + deltaYaw;
+    double deltaX = odomPosPoint.getX() - lastOdomPosPoint.getX();
+    double deltaY = odomPosPoint.getY() - lastOdomPosPoint.getY();
+    double deltaYaw = odomPosPoint.getYaw() - lastOdomPosPoint.getYaw();
+    gnssPosPoint.setX(gnssPosPoint.getX() + deltaX);
+    gnssPosPoint.setY(gnssPosPoint.getY() + deltaY);
+    double yawResult = gnssPosPoint.getYaw() + deltaYaw;
 
     while (yawResult < -180.0)
         yawResult += 360.0;
     while (yawResult >= 180.0)
         yawResult -= 360.0;
 
-    gnssPosition.setYaw(yawResult);
-    gnssPosition.setTime(odomPosition.getTime());
-    mVehicleState->setPosition(gnssPosition);
-    prevOdomPosition = odomPosition;
+    gnssPosPoint.setYaw(yawResult);
+    gnssPosPoint.setTime(odomPosPoint.getTime());
+    mObjectState->setPosition(gnssPosPoint);
 
+    GnssFixStatus gnssFixStatus;
     if (perturbationFn) {
-        return perturbationFn(odomPosition.getTime(), mVehicleState);
+        gnssFixStatus = perturbationFn(odomPosPoint.getTime(), mObjectState);
+        gnssPosPoint = mObjectState->getPosition(PosType::GNSS);
+    } else {
+        gnssFixStatus.isFusedOnChip = true;
+        gnssFixStatus.fixType = GNSS_FIX_TYPE::FIX_3D;
+        gnssFixStatus.horizontalAccuracy = 0.0;
+        gnssFixStatus.verticalAccuracy = 0.0;
+        gnssFixStatus.headingAccuracy = 0.0;
+        gnssFixStatus.lastRtcmCorrectionAge = 0;
+        gnssFixStatus.numSatellites = 0;
     }
 
-    return true;
+    emit updatedGNSSPositionAndYaw(mObjectState, QLineF(lastGNSSPoint, gnssPosPoint.getPoint()).length(), gnssFixStatus);
+    lastGNSSPoint = gnssPosPoint.getPoint();
+    lastOdomPosPoint = odomPosPoint;
 }

--- a/sensors/gnss/gnssreceiver.cpp
+++ b/sensors/gnss/gnssreceiver.cpp
@@ -53,3 +53,49 @@ void GNSSReceiver::simulationStep(const std::function<GnssFixStatus(QTime, QShar
     lastGNSSPoint = gnssPosPoint.getPoint();
     lastOdomPosPoint = odomPosPoint;
 }
+
+void GNSSReceiver::updateGNSSPositionAndYaw(llh_t llh, double heading, bool isFusedOnChip)
+{
+
+    PosPoint gnssPos = mObjectState->getPosition(PosType::GNSS);
+    xyz_t xyz = {0.0, 0.0, 0.0};
+
+    if (!mObjectState->isEnuReferenceSet()) {
+        mObjectState->setEnuRef(llh);
+        qDebug() << "GNSSReceiver: ENU reference point set to" << llh.latitude << llh.longitude << llh.height;
+    } else
+        xyz = coordinateTransforms::llhToEnu(mObjectState->getEnuRef(), llh);
+
+    // Position
+    gnssPos.setXYZ(xyz);
+
+    double vehYaw_radENU = 0.0;
+    if (isFusedOnChip) {
+        double yaw_degENU = coordinateTransforms::yawNEDtoENU(heading) + mAChipOrientationOffset.yawOffset_deg;
+
+        // normalize to [-180.0:180.0]
+        while (yaw_degENU < -180.0)
+            yaw_degENU += 360.0;
+        while (yaw_degENU >= 180.0)
+            yaw_degENU -= 360.0;
+
+        gnssPos.setYaw(yaw_degENU);
+
+        vehYaw_radENU = yaw_degENU * M_PI / 180.0;
+
+        // Apply Chip to rear axle offset if set.
+        if (mChipToBaseOffset.x != 0.0 || mChipToBaseOffset.y != 0.0) {
+            gnssPos.updateWithOffsetAndYawRotation(mChipToBaseOffset, vehYaw_radENU);
+        }
+    } else { // Assumes fused yaw is updated.
+        PosPoint fusedPos = mObjectState->getPosition(PosType::fused);
+        vehYaw_radENU = fusedPos.getYaw() * M_PI / 180.0;
+
+        // Apply antenna to rear axle offset if set.
+        xyz_t mAntennaToRearAxleOffset = mAntennaToChipOffset + mChipToBaseOffset;
+        if (mAntennaToRearAxleOffset.x != 0.0 || mAntennaToRearAxleOffset.y != 0.0) {
+            gnssPos.updateWithOffsetAndYawRotation(mAntennaToRearAxleOffset, vehYaw_radENU);
+        }
+    }
+    mObjectState->setPosition(gnssPos);
+}

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -57,7 +57,6 @@ public:
     RECEIVER_STATE getReceiverState() { return mReceiverState; }
     void setReceiverState(RECEIVER_STATE state) { mReceiverState = state; }
     virtual void aboutToShutdown() {};
-    virtual void readVehicleSpeedForPositionFusion() {};
     virtual void setGnssFixAccuracy(GnssFixAccuracy gnssFixAccuracy) { mGnssFixAccuracy = gnssFixAccuracy; }
     virtual GnssFixAccuracy getGnssFixAccuracy() { return mGnssFixAccuracy; }
 

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -45,7 +45,7 @@ class GNSSReceiver : public QObject
 {
     Q_OBJECT
 public:
-    GNSSReceiver(QSharedPointer<VehicleState> vehicleState);
+    GNSSReceiver(QSharedPointer<ObjectState> objectState);
 
     bool simulationStep(const std::function<bool(QTime, QSharedPointer<VehicleState>)> &perturbationFn = nullptr);
 
@@ -60,6 +60,12 @@ public:
     virtual void setGnssFixAccuracy(GnssFixAccuracy gnssFixAccuracy) { mGnssFixAccuracy = gnssFixAccuracy; }
     virtual GnssFixAccuracy getGnssFixAccuracy() { return mGnssFixAccuracy; }
 
+    virtual void setPosGNSSisFused(bool posGNSSisFused) { mPosGNSSisFused = posGNSSisFused; }
+    virtual bool getPosGNSSisFused() { return mPosGNSSisFused; }
+
+    virtual void setGnssFixType(GNSS_FIX_TYPE gnssFixType) { mFixType = gnssFixType; }
+    virtual GNSS_FIX_TYPE getGnssFixType() { return mFixType; }
+
 protected:
     virtual void shutdownGNSSReceiver() {};
 
@@ -67,11 +73,12 @@ protected:
     RECEIVER_STATE mReceiverState = RECEIVER_STATE::UNKNOWN;
     GNSS_FIX_TYPE mFixType = GNSS_FIX_TYPE::NO_FIX;
 
-    QSharedPointer<VehicleState> mVehicleState;
+    QSharedPointer<ObjectState> mObjectState;
     struct {double rollOffset_deg, pitchOffset_deg, yawOffset_deg;} mAChipOrientationOffset; // in degrees
     xyz_t mAntennaToChipOffset = {0.0, 0.0, 0.0}; // in meters
     xyz_t mChipToRearAxleOffset = {0.0, 0.0, 0.0}; // in meters
     GnssFixAccuracy mGnssFixAccuracy;
+    bool mPosGNSSisFused = false;
 };
 
 #endif // GNSSRECEIVER_H

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -8,6 +8,8 @@
 #ifndef GNSSRECEIVER_H
 #define GNSSRECEIVER_H
 
+#include <QDebug>
+#include <QLineF>
 #include <QObject>
 #include <QSharedPointer>
 #include <limits>
@@ -75,6 +77,10 @@ public:
     RECEIVER_STATE getReceiverState() { return mReceiverState; }
     void setReceiverState(RECEIVER_STATE state) { mReceiverState = state; }
     virtual void aboutToShutdown() {};
+    virtual void updateGNSSPositionAndYaw(llh_t llh, double heading, bool isFusedOnChip);
+
+signals:
+    void updatedGNSSPositionAndYaw(QSharedPointer<ObjectState> objectState, double distanceMoved, GnssFixStatus gnssFixStatus);
 
 protected:
     virtual void shutdownGNSSReceiver() {};

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -16,7 +16,14 @@
 #include "vehicles/vehiclestate.h"
 
 
-enum class RECEIVER_VARIANT {UNKNOWN, WAYWISE_SIMULATED, EXTERNAL, UBLX_ZED_F9P, UBLX_ZED_F9R};
+enum class RECEIVER_VARIANT
+{
+    UNKNOWN,
+    WAYWISE_SIMULATED,
+    EXTERNAL,
+    UBLX_ZED_F9P,
+    UBLX_ZED_F9R
+};
 
 enum class RECEIVER_STATE
 {
@@ -32,13 +39,24 @@ enum class RECEIVER_STATE
     BACKUP_CREATED
 };
 
-enum class GNSS_FIX_TYPE {NO_FIX, DEAD_RECKONING_ONLY, FIX_2D, FIX_3D, FIX_GNSS_DR_COMBINED, FIX_TIME_ONLY};
-
-struct GnssFixAccuracy
+enum class GNSS_FIX_TYPE
 {
-  float horizontal = std::numeric_limits<float>::infinity();
-  float vertical = std::numeric_limits<float>::infinity();
-  float heading = std::numeric_limits<float>::infinity();
+    NO_FIX,
+    DEAD_RECKONING_ONLY_FIX,
+    FIX_2D,
+    FIX_3D,
+    GNSS_DR_COMBINED_FIX,
+    TIME_ONLY_FIX
+};
+struct GnssFixStatus
+{
+    bool isFusedOnChip = false;
+    GNSS_FIX_TYPE fixType = GNSS_FIX_TYPE::NO_FIX;
+    float horizontalAccuracy = std::numeric_limits<float>::infinity();
+    float verticalAccuracy = std::numeric_limits<float>::infinity();
+    float headingAccuracy = std::numeric_limits<float>::infinity();
+    uint8_t lastRtcmCorrectionAge = 0;
+    uint8_t numSatellites = 0;
 };
 
 class GNSSReceiver : public QObject
@@ -47,38 +65,29 @@ class GNSSReceiver : public QObject
 public:
     GNSSReceiver(QSharedPointer<ObjectState> objectState);
 
-    bool simulationStep(const std::function<bool(QTime, QSharedPointer<VehicleState>)> &perturbationFn = nullptr);
+    void simulationStep(const std::function<GnssFixStatus(QTime, QSharedPointer<ObjectState>)> &perturbationFn = nullptr);
 
     void setReceiverVariant(RECEIVER_VARIANT receiverVariant) { mReceiverVariant = receiverVariant; }
     RECEIVER_VARIANT getReceiverVariant() { return mReceiverVariant; }
     virtual void setChipOrientationOffset(double roll_deg, double pitch_deg, double yaw_deg) { mAChipOrientationOffset = {roll_deg, pitch_deg, yaw_deg}; }
     virtual void setAntennaToChipOffset(double xOffset, double yOffset, double zOffset) { mAntennaToChipOffset = {xOffset, yOffset, zOffset}; }
-    virtual void setChipToRearAxleOffset(double xOffset, double yOffset, double zOffset) { mChipToRearAxleOffset = {xOffset, yOffset, zOffset}; }
+    virtual void setChipToBaseOffset(double xOffset, double yOffset, double zOffset) { mChipToBaseOffset = {xOffset, yOffset, zOffset}; }
     RECEIVER_STATE getReceiverState() { return mReceiverState; }
     void setReceiverState(RECEIVER_STATE state) { mReceiverState = state; }
     virtual void aboutToShutdown() {};
-    virtual void setGnssFixAccuracy(GnssFixAccuracy gnssFixAccuracy) { mGnssFixAccuracy = gnssFixAccuracy; }
-    virtual GnssFixAccuracy getGnssFixAccuracy() { return mGnssFixAccuracy; }
-
-    virtual void setPosGNSSisFused(bool posGNSSisFused) { mPosGNSSisFused = posGNSSisFused; }
-    virtual bool getPosGNSSisFused() { return mPosGNSSisFused; }
-
-    virtual void setGnssFixType(GNSS_FIX_TYPE gnssFixType) { mFixType = gnssFixType; }
-    virtual GNSS_FIX_TYPE getGnssFixType() { return mFixType; }
 
 protected:
     virtual void shutdownGNSSReceiver() {};
 
+    // Static variables
     RECEIVER_VARIANT mReceiverVariant = RECEIVER_VARIANT::UNKNOWN;
-    RECEIVER_STATE mReceiverState = RECEIVER_STATE::UNKNOWN;
-    GNSS_FIX_TYPE mFixType = GNSS_FIX_TYPE::NO_FIX;
-
-    QSharedPointer<ObjectState> mObjectState;
     struct {double rollOffset_deg, pitchOffset_deg, yawOffset_deg;} mAChipOrientationOffset; // in degrees
     xyz_t mAntennaToChipOffset = {0.0, 0.0, 0.0}; // in meters
-    xyz_t mChipToRearAxleOffset = {0.0, 0.0, 0.0}; // in meters
-    GnssFixAccuracy mGnssFixAccuracy;
-    bool mPosGNSSisFused = false;
+    xyz_t mChipToBaseOffset = {0.0, 0.0, 0.0}; // in meters
+
+    // Dynamic variables
+    QSharedPointer<ObjectState> mObjectState;
+    RECEIVER_STATE mReceiverState = RECEIVER_STATE::UNKNOWN;
 };
 
 #endif // GNSSRECEIVER_H

--- a/sensors/gnss/gnssreceiver.h
+++ b/sensors/gnss/gnssreceiver.h
@@ -67,7 +67,7 @@ class GNSSReceiver : public QObject
 public:
     GNSSReceiver(QSharedPointer<ObjectState> objectState);
 
-    void simulationStep(const std::function<GnssFixStatus(QTime, QSharedPointer<ObjectState>)> &perturbationFn = nullptr);
+    void simulationStep(const std::function<GnssFixStatus(QTime, QSharedPointer<ObjectState>)> &simulationFn = nullptr);
 
     void setReceiverVariant(RECEIVER_VARIANT receiverVariant) { mReceiverVariant = receiverVariant; }
     RECEIVER_VARIANT getReceiverVariant() { return mReceiverVariant; }
@@ -77,10 +77,11 @@ public:
     RECEIVER_STATE getReceiverState() { return mReceiverState; }
     void setReceiverState(RECEIVER_STATE state) { mReceiverState = state; }
     virtual void aboutToShutdown() {};
-    virtual void updateGNSSPositionAndYaw(llh_t llh, double heading, bool isFusedOnChip);
+    virtual void updateGNSSPositionAndOrientation(llh_t llh, double heading_degNED, bool isFusedOnChip);
+    virtual void updateGNSSPositionAndOrientation(llh_t llh, rpy_t rpy_degNED, bool isFusedOnChip);
 
 signals:
-    void updatedGNSSPositionAndYaw(QSharedPointer<ObjectState> objectState, double distanceMoved, GnssFixStatus gnssFixStatus);
+    void updatedGNSSPositionAndOrientation(QSharedPointer<ObjectState> objectState, double distanceMoved, GnssFixStatus gnssFixStatus);
 
 protected:
     virtual void shutdownGNSSReceiver() {};

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -350,49 +350,9 @@ void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
         qDebug() << "UbloxRover: assuming" << leapSeconds_ms / 1000 << "seconds difference between GNSS time and UTC.";
         initializationDone = true;
     } else {
+        GNSSReceiver::updateGNSSPositionAndYaw({pvt.lat, pvt.lon, pvt.height}, pvt.head_veh, pvt.head_veh_valid);
+
         PosPoint gnssPos = mObjectState->getPosition(PosType::GNSS);
-
-        llh_t llh = {pvt.lat, pvt.lon, pvt.height};
-        xyz_t xyz = {0.0, 0.0, 0.0};
-
-        if (!mVehicleState->isEnuReferenceSet()) {
-            mVehicleState->setEnuRef(llh);
-            qDebug() << "UbloxRover: ENU reference point set to" << pvt.lat << pvt.lon << pvt.height;
-        } else
-            xyz = coordinateTransforms::llhToEnu(mVehicleState->getEnuRef(), llh);
-
-        // Position
-        gnssPos.setXYZ(xyz);
-
-        double vehYaw_radENU = 0.0;
-        if (mReceiverVariant == RECEIVER_VARIANT::UBLX_ZED_F9R) {
-            double yaw_degENU = coordinateTransforms::yawNEDtoENU(pvt.head_veh) + mAChipOrientationOffset.yawOffset_deg;
-
-            // normalize to [-180.0:180.0]
-            while (yaw_degENU < -180.0)
-                yaw_degENU += 360.0;
-            while (yaw_degENU >= 180.0)
-                yaw_degENU -= 360.0;
-
-            gnssPos.setYaw(yaw_degENU);
-
-            vehYaw_radENU = yaw_degENU * M_PI / 180.0;
-
-            // Apply Chip to rear axle offset if set.
-            if (mChipToRearAxleOffset.x != 0.0 || mChipToRearAxleOffset.y != 0.0) {
-                gnssPos.updateWithOffsetAndYawRotation(mChipToRearAxleOffset, vehYaw_radENU);
-            }
-        } else { // Assumes fused yaw is updated.
-            PosPoint fusedPos = mObjectState->getPosition(PosType::fused);
-            vehYaw_radENU = fusedPos.getYaw() * M_PI / 180.0;
-
-            // Apply antenna to rear axle offset if set.
-            xyz_t mAntennaToRearAxleOffset = mAntennaToChipOffset + mChipToRearAxleOffset;
-            if (mAntennaToRearAxleOffset.x != 0.0 || mAntennaToRearAxleOffset.y != 0.0) {
-                gnssPos.updateWithOffsetAndYawRotation(mAntennaToRearAxleOffset, vehYaw_radENU);
-            }
-        }
-
         // Time and speed
         gnssPos.setTime(QTime::fromMSecsSinceStartOfDay((pvt.i_tow % ms_per_day) - leapSeconds_ms));
 //        qDebug() << "UbloxRover, gnssPos.getTime() - msSinceTodayUTC:" << QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()).msecsSinceStartOfDay() - gnssPos.getTime();
@@ -400,18 +360,21 @@ void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
 
         mObjectState->setPosition(gnssPos);
 
-        // Accuracy
-        mGnssFixAccuracy.horizontal = pvt.h_acc;
-        mGnssFixAccuracy.vertical = pvt.v_acc;
-        mGnssFixAccuracy.heading = pvt.head_acc;
+        // GNSS fix status
+        GnssFixStatus gnssFixStatus;
+        gnssFixStatus.isFusedOnChip = pvt.head_veh_valid;
+        gnssFixStatus.horizontalAccuracy = pvt.h_acc;
+        gnssFixStatus.verticalAccuracy = pvt.v_acc;
+        gnssFixStatus.headingAccuracy = pvt.head_acc;
+        gnssFixStatus.fixType = static_cast<GNSS_FIX_TYPE>(pvt.fix_type);
+        gnssFixStatus.lastRtcmCorrectionAge = pvt.last_correction_age;
+        gnssFixStatus.numSatellites = pvt.num_sv;
 
-        mPosGNSSisFused = pvt.head_veh_valid;
-
-        static xyz_t lastXyz;
-        emit updatedGNSSPositionAndYaw(mObjectState, QLineF(QPointF(lastXyz.x, lastXyz.y), gnssPos.getPoint()).length(), pvt.head_veh_valid);
+        static QPointF lastGnssPoint;
+        emit updatedGNSSPositionAndYaw(mObjectState, QLineF(lastGnssPoint, gnssPos.getPoint()).length(), gnssFixStatus);
         emit txNavPvt(pvt);
 
-        lastXyz = xyz;
+        lastGnssPoint = gnssPos.getPoint();
     }
 }
 

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -13,7 +13,7 @@ UbloxRover::UbloxRover(QSharedPointer<ObjectState> objectState)
 {
     // Use GNSS reception to update location
     connect(&mUblox, &Ublox::rxNavPvt, this, [this](const ubx_nav_pvt &pvt){
-        if (mReceiverVariant == RECEIVER_VARIANT::UBLX_ZED_F9P && mReceiverState != RECEIVER_STATE::READY) {
+        if (mReceiverState != RECEIVER_STATE::READY) {
             setReceiverState(RECEIVER_STATE::READY);
         }
         updateGNSSPositionAndYaw(pvt);
@@ -69,7 +69,7 @@ UbloxRover::UbloxRover(QSharedPointer<ObjectState> objectState)
             } break;
             case RECEIVER_STATE::READY:
             {
-                if (status.fusion_mode == 0) { // Recalibrating sensors
+                if (status.fusion_mode == 0 && mFusionOnChip) { // Recalibrating sensors
                     setReceiverState(RECEIVER_STATE::CALIBRATING);
                     qDebug() << "UbloxRover: Recalibrating sensors";
                 }
@@ -78,7 +78,7 @@ UbloxRover::UbloxRover(QSharedPointer<ObjectState> objectState)
                 break;
         }
 
-        if (mPrintVerbose) {
+        if (mPrintVerbose && mFusionOnChip) {
             qDebug() << "---------------------------------";
             qDebug() << "ESF-STATUS data:"
                     // << "\nVersion:" << status.version
@@ -266,53 +266,62 @@ bool UbloxRover::configureUblox()
     if (mReceiverVariant == RECEIVER_VARIANT::UBLX_ZED_F9R) {
         // F9R specific configuration
 
-        if (mCalibrateEsfSensors) { // TODO: do a valget to compare the key values and change them if required
-            mUblox.ubloxCfgAppendEnableSf(buffer, &ind, true); // enable/disable sensor fusion
+        if (mFusionOnChip) { // TODO: do a valget to compare the key values and change them if required
+            mUblox.ubloxCfgAppendEnableSf(buffer, &ind, true); // enable sensor fusion
 
-            // Set the odometer input configuration for sensor fusion
-            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_SFODO_USE_SPEED, true); // Use speed data for fusion, speed should be sent as mm/s, signed int.
-            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_SFODO_USE_WT_PIN, false); // Disable wheel tick input
-            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_SFODO_FREQUENCY, mSpeedDataInputRate); // Speed data frequency (Hz), should be accurate upto 10%, set it to 0 for automatic estimation
-            // mUblox.ubloxCfgAppendU2Key(buffer, &ind, CFG_SFODO_LATENCY, 5); // Wheel tick/speed data latency (in ms), if not provided, it is assumed to be 0.
-            mUblox.ubloxCfgAppendU4Key(buffer, &ind, CFG_SFODO_QUANT_ERROR, 1e3); // Wheel tick/speed data quantization error (units: 1e-6), set it to 0 for automatic estimation, 1e3 = 1mm/s
+            if (mCalibrateEsfSensors) {
+                // Set the odometer input configuration for sensor fusion
+                mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_SFODO_USE_SPEED, true); // Use speed data for fusion, speed should be sent as mm/s, signed int.
+                mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_SFODO_USE_WT_PIN, false); // Disable wheel tick input
+                mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_SFODO_FREQUENCY, mSpeedDataInputRate); // Speed data frequency (Hz), should be accurate upto 10%, set it to 0 for automatic estimation
+                // mUblox.ubloxCfgAppendU2Key(buffer, &ind, CFG_SFODO_LATENCY, 5); // Wheel tick/speed data latency (in ms), if not provided, it is assumed to be 0.
+                mUblox.ubloxCfgAppendU4Key(buffer, &ind, CFG_SFODO_QUANT_ERROR, 1e3); // Wheel tick/speed data quantization error (units: 1e-6), set it to 0 for automatic estimation, 1e3 = 1mm/s
 
-            // IMU mount alignment
-            uint32_t yaw_deg_scaled = static_cast<uint32_t>(mAChipOrientationOffset.yawOffset_deg * 100);
-            uint16_t pitch_deg_scaled = static_cast<uint16_t>(mAChipOrientationOffset.pitchOffset_deg * 100);
-            uint16_t roll_deg_scaled = static_cast<uint16_t>(mAChipOrientationOffset.rollOffset_deg * 100);
-            mUblox.ubloxCfgAppendMntalg(buffer, &ind, mESFAlgAutoMntAlgOn, yaw_deg_scaled, pitch_deg_scaled, roll_deg_scaled); // IMU mount alignment, in degrees with a scale of 1/1e-2
+                // IMU mount alignment
+                uint32_t yaw_deg_scaled = static_cast<uint32_t>(mAChipOrientationOffset.yawOffset_deg * 100);
+                uint16_t pitch_deg_scaled = static_cast<uint16_t>(mAChipOrientationOffset.pitchOffset_deg * 100);
+                uint16_t roll_deg_scaled = static_cast<uint16_t>(mAChipOrientationOffset.rollOffset_deg * 100);
+                mUblox.ubloxCfgAppendMntalg(buffer, &ind, mESFAlgAutoMntAlgOn, yaw_deg_scaled, pitch_deg_scaled, roll_deg_scaled); // IMU mount alignment, in degrees with a scale of 1/1e-2
 
-            // Set the offset between the IMU and the antenna
-            uint16_t imu2ant_la_x_cm = static_cast<uint16_t>(-mAntennaToChipOffset.x * 100);
-            uint16_t imu2ant_la_y_cm = static_cast<uint16_t>(-mAntennaToChipOffset.y * 100);
-            uint16_t imu2ant_la_z_cm = static_cast<uint16_t>(-mAntennaToChipOffset.z * 100);
-            mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_X, imu2ant_la_x_cm); // IMU to antenna lever arm X (cm)
-            mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_Y, imu2ant_la_y_cm); // IMU to antenna lever arm Y (cm)
-            mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_Z, imu2ant_la_z_cm); // IMU to antenna lever arm Z (cm)
+                // Set the offset between the IMU and the antenna
+                uint16_t imu2ant_la_x_cm = static_cast<uint16_t>(-mAntennaToChipOffset.x * 100);
+                uint16_t imu2ant_la_y_cm = static_cast<uint16_t>(-mAntennaToChipOffset.y * 100);
+                uint16_t imu2ant_la_z_cm = static_cast<uint16_t>(-mAntennaToChipOffset.z * 100);
+                mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_X, imu2ant_la_x_cm); // IMU to antenna lever arm X (cm)
+                mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_Y, imu2ant_la_y_cm); // IMU to antenna lever arm Y (cm)
+                mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_Z, imu2ant_la_z_cm); // IMU to antenna lever arm Z (cm)
 
-            // Set the offset between the IMU and the vehicle reference point
-            uint16_t imu2vrp_la_x_cm = static_cast<uint16_t>(mChipToBaseOffset.x * 100);
-            uint16_t imu2vrp_la_y_cm = static_cast<uint16_t>(mChipToBaseOffset.y * 100);
-            uint16_t imu2vrp_la_z_cm = static_cast<uint16_t>(mChipToBaseOffset.z * 100);
-            mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_X, imu2vrp_la_x_cm); // IMU to vehicle reference point lever arm X (cm)
-            mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_Y, imu2vrp_la_y_cm); // IMU to vehicle reference point lever arm Y (cm)
-            mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_Z, imu2vrp_la_z_cm); // IMU to vehicle reference point lever arm Z (cm)
-        }
+                // Set the offset between the IMU and the vehicle reference point
+                uint16_t imu2vrp_la_x_cm = static_cast<uint16_t>(mChipToBaseOffset.x * 100);
+                uint16_t imu2vrp_la_y_cm = static_cast<uint16_t>(mChipToBaseOffset.y * 100);
+                uint16_t imu2vrp_la_z_cm = static_cast<uint16_t>(mChipToBaseOffset.z * 100);
+                mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_X, imu2vrp_la_x_cm); // IMU to vehicle reference point lever arm X (cm)
+                mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_Y, imu2vrp_la_y_cm); // IMU to vehicle reference point lever arm Y (cm)
+                mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_Z, imu2vrp_la_z_cm); // IMU to vehicle reference point lever arm Z (cm)
+            }
 
-        // Set the output rates for the messages
-        mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_ESF_STATUS_USB, 1); // UBX-ESF-STATUS rate
+            // Set the output rates for the messages
+            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_ESF_STATUS_USB, 1); // UBX-ESF-STATUS rate
 
-        // Disable nav prio mode by default at startup, it will be enabled when the ESF sensors are calibrated
-        mUblox.ubloxCfgAppendRate(buffer, &ind, 1000, 1, 0, 0); // Disable nav prio mode
-        mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 0); // UBX-NAV-PVT rate
+            // Disable nav prio mode by default at startup, it will be enabled when the ESF sensors are calibrated
+            mUblox.ubloxCfgAppendRate(buffer, &ind, 1000, 1, 0, 0); // Disable nav prio mode
+            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 0); // UBX-NAV-PVT rate
 
-        // if (mPrintVerbose) { // TODO: handle this after configuration is done by writing to just ram and bbr
-        //     // mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_ESF_MEAS_USB, 1); // UBX-ESF-MEAS rate
-        //     mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_STATUS_USB, 1); // UBX-NAV-STATUS rate
-        // }
 
-        if (mESFAlgAutoMntAlgOn) {
-            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_ESF_ALG_USB, 1); // UBX-ESF-ALG rate
+            // if (mPrintVerbose) { // TODO: handle this after configuration is done by writing to just ram and bbr
+            //     // mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_ESF_MEAS_USB, 1); // UBX-ESF-MEAS rate
+            //     mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_STATUS_USB, 1); // UBX-NAV-STATUS rate
+            // }
+
+            if (mESFAlgAutoMntAlgOn) {
+                mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_ESF_ALG_USB, 1); // UBX-ESF-ALG rate
+            }
+        } else {
+            mUblox.ubloxCfgAppendEnableSf(buffer, &ind, false); // disable sensor fusion
+
+            int gNSSMeasurementPeriod_ms = 1000 / mNavPvtMessageRate; // convert Hz to ms
+            mUblox.ubloxCfgAppendRate(buffer, &ind, gNSSMeasurementPeriod_ms, 1, 0); // One measurement per nav solution
+            mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 1); // Output NAV-PVT every nav solution
         }
 
         result &= mUblox.ubloxCfgValset(buffer, ind, true, true, mCalibrateEsfSensors, 0); // timeout set to 0 as ack is not being received
@@ -329,7 +338,7 @@ bool UbloxRover::configureUblox()
         mUblox.ubloxCfgAppendRate(buffer, &ind, gNSSMeasurementPeriod_ms, 1, 0); // One measurement per nav solution
         mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 1); // Output NAV-PVT every nav solution
 
-        result &= mUblox.ubloxCfgValset(buffer, ind, true, true, mCalibrateEsfSensors, 0); // timeout set to 0 as ack is not being received
+        result &= mUblox.ubloxCfgValset(buffer, ind, true, true, false, 0); // timeout set to 0 as ack is not being received
 
         qDebug() << "UbloxRover: F9P configuration" << (result ? "was successful" : "reported an error");
         mCreateBackupWithSoS = true;

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -16,7 +16,7 @@ UbloxRover::UbloxRover(QSharedPointer<ObjectState> objectState)
         if (mReceiverState != RECEIVER_STATE::READY) {
             setReceiverState(RECEIVER_STATE::READY);
         }
-        updateGNSSPositionAndYaw(pvt);
+        updateGNSSPositionAndOrientation(pvt);
     });
 
     // Fordward received NMEA GGA messages
@@ -348,7 +348,7 @@ bool UbloxRover::configureUblox()
     return true;
 }
 
-void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
+void UbloxRover::updateGNSSPositionAndOrientation(const ubx_nav_pvt &pvt)
 {
     static bool initializationDone = false;
     static int leapSeconds_ms = 0;
@@ -358,7 +358,7 @@ void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
         qDebug() << "UbloxRover: assuming" << leapSeconds_ms / 1000 << "seconds difference between GNSS time and UTC.";
         initializationDone = true;
     } else {
-        GNSSReceiver::updateGNSSPositionAndYaw({pvt.lat, pvt.lon, pvt.height}, pvt.head_veh, pvt.head_veh_valid);
+        GNSSReceiver::updateGNSSPositionAndOrientation({pvt.lat, pvt.lon, pvt.height}, pvt.head_veh, pvt.head_veh_valid);
 
         PosPoint gnssPos = mObjectState->getPosition(PosType::GNSS);
         // Time and speed
@@ -379,7 +379,7 @@ void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
         gnssFixStatus.numSatellites = pvt.num_sv;
 
         static QPointF lastGnssPoint;
-        emit updatedGNSSPositionAndYaw(mObjectState, QLineF(lastGnssPoint, gnssPos.getPoint()).length(), gnssFixStatus);
+        emit updatedGNSSPositionAndOrientation(mObjectState, QLineF(lastGnssPoint, gnssPos.getPoint()).length(), gnssFixStatus);
         emit txNavPvt(pvt);
 
         lastGnssPoint = gnssPos.getPoint();

--- a/sensors/gnss/ubloxrover.cpp
+++ b/sensors/gnss/ubloxrover.cpp
@@ -112,7 +112,6 @@ UbloxRover::UbloxRover(QSharedPointer<ObjectState> objectState)
 
     // Print nav-status message
     connect(&mUblox, &Ublox::rxNavStatus, this, [this](const ubx_nav_status &status) {
-        mFixType = static_cast<GNSS_FIX_TYPE>(status.gps_fix);
         if (mPrintVerbose && mReceiverState == RECEIVER_STATE::CALIBRATING) {
             qDebug() << "---------------------------------";
             qDebug() << "NAV-STATUS data:"
@@ -277,7 +276,7 @@ bool UbloxRover::configureUblox()
             // mUblox.ubloxCfgAppendU2Key(buffer, &ind, CFG_SFODO_LATENCY, 5); // Wheel tick/speed data latency (in ms), if not provided, it is assumed to be 0.
             mUblox.ubloxCfgAppendU4Key(buffer, &ind, CFG_SFODO_QUANT_ERROR, 1e3); // Wheel tick/speed data quantization error (units: 1e-6), set it to 0 for automatic estimation, 1e3 = 1mm/s
 
-            // Automatic IMU mount alignment is not supported for MOWER and E-Scooter models
+            // IMU mount alignment
             uint32_t yaw_deg_scaled = static_cast<uint32_t>(mAChipOrientationOffset.yawOffset_deg * 100);
             uint16_t pitch_deg_scaled = static_cast<uint16_t>(mAChipOrientationOffset.pitchOffset_deg * 100);
             uint16_t roll_deg_scaled = static_cast<uint16_t>(mAChipOrientationOffset.rollOffset_deg * 100);
@@ -292,9 +291,9 @@ bool UbloxRover::configureUblox()
             mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFIMU_IMU2ANT_LA_Z, imu2ant_la_z_cm); // IMU to antenna lever arm Z (cm)
 
             // Set the offset between the IMU and the vehicle reference point
-            uint16_t imu2vrp_la_x_cm = static_cast<uint16_t>(mChipToRearAxleOffset.x * 100);
-            uint16_t imu2vrp_la_y_cm = static_cast<uint16_t>(mChipToRearAxleOffset.y * 100);
-            uint16_t imu2vrp_la_z_cm = static_cast<uint16_t>(mChipToRearAxleOffset.z * 100);
+            uint16_t imu2vrp_la_x_cm = static_cast<uint16_t>(mChipToBaseOffset.x * 100);
+            uint16_t imu2vrp_la_y_cm = static_cast<uint16_t>(mChipToBaseOffset.y * 100);
+            uint16_t imu2vrp_la_z_cm = static_cast<uint16_t>(mChipToBaseOffset.z * 100);
             mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_X, imu2vrp_la_x_cm); // IMU to vehicle reference point lever arm X (cm)
             mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_Y, imu2vrp_la_y_cm); // IMU to vehicle reference point lever arm Y (cm)
             mUblox.ubloxCfgAppendI2Key(buffer, &ind, CFG_SFODO_IMU2VRP_LA_Z, imu2vrp_la_z_cm); // IMU to vehicle reference point lever arm Z (cm)
@@ -326,9 +325,9 @@ bool UbloxRover::configureUblox()
     } else if (mReceiverVariant == RECEIVER_VARIANT::UBLX_ZED_F9P) {
         // F9P specific configuration
 
-        int gNSSMeasurementPeriod_ms = 1000 / mGNSSMeasurementRate; // convert Hz to ms
-        mUblox.ubloxCfgAppendRate(buffer, &ind, gNSSMeasurementPeriod_ms, 1, 0); // Set rate
-        mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 1); // Enable UBX-NAV-PVT
+        int gNSSMeasurementPeriod_ms = 1000 / mNavPvtMessageRate; // convert Hz to ms
+        mUblox.ubloxCfgAppendRate(buffer, &ind, gNSSMeasurementPeriod_ms, 1, 0); // One measurement per nav solution
+        mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 1); // Output NAV-PVT every nav solution
 
         result &= mUblox.ubloxCfgValset(buffer, ind, true, true, mCalibrateEsfSensors, 0); // timeout set to 0 as ack is not being received
 
@@ -493,9 +492,9 @@ bool UbloxRover::switchNavPrioMode(bool navPrioMode)
     int ind = 0;
 
     if (navPrioMode) {
-        int gNSSMeasurementPeriod_ms = 1000 / mGNSSMeasurementRate; // convert Hz to ms
-        mUblox.ubloxCfgAppendRate(buffer, &ind, gNSSMeasurementPeriod_ms, 1, 0, mNavPrioMessageRate); // Enable/disable nav prio mode
-        mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 1); // UBX-NAV-PVT rate
+        int gNSSMeasurementPeriod_ms = 1000 / mNavPvtMessageRate; // convert Hz to ms
+        mUblox.ubloxCfgAppendRate(buffer, &ind, gNSSMeasurementPeriod_ms, 1, 0, mNavPvtMessageRate); // Enable nav prio mode, one measurement per nav solution
+        mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 1); // Output NAV-PVT every nav solution
     } else {
         mUblox.ubloxCfgAppendRate(buffer, &ind, 1000, 1, 0, 0); // Disable nav prio mode
         mUblox.ubloxCfgAppendE1U1Key(buffer, &ind, CFG_MSGOUT_UBX_NAV_PVT_USB, 0); // UBX-NAV-PVT rate

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -20,7 +20,7 @@ class UbloxRover : public GNSSReceiver
 {
     Q_OBJECT
 public:
-    UbloxRover(QSharedPointer<VehicleState> vehicleState);
+    UbloxRover(QSharedPointer<ObjectState> objectState);
     bool connectSerial(const QSerialPortInfo &serialPortInfo);
     bool isSerialConnected();
     void writeRtcmToUblox(QByteArray data);
@@ -33,10 +33,10 @@ public:
     void setPrintVerbose(bool printVerbose) { mPrintVerbose = printVerbose; }
     void setESFAlgAutoMntAlgOn(bool esfAlgAutoMntAlgOn) { mESFAlgAutoMntAlgOn = esfAlgAutoMntAlgOn; }
     virtual void aboutToShutdown() override;
-    virtual void readVehicleSpeedForPositionFusion();
+    virtual void readObjectSpeedForPositionFusion();
 
 signals:
-    void updatedGNSSPositionAndYaw(QSharedPointer<VehicleState> vehicleState, double distanceMoved, bool fused);
+    void updatedGNSSPositionAndYaw(QSharedPointer<ObjectState> objectState, double distanceMoved, bool fused);
     void txNavPvt(const ubx_nav_pvt &pvt);
     void gotNmeaGga(const QByteArray& nmeaGgaStr);
 

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -33,7 +33,7 @@ public:
     void setPrintVerbose(bool printVerbose) { mPrintVerbose = printVerbose; }
     void setESFAlgAutoMntAlgOn(bool esfAlgAutoMntAlgOn) { mESFAlgAutoMntAlgOn = esfAlgAutoMntAlgOn; }
     virtual void aboutToShutdown() override;
-    virtual void readVehicleSpeedForPositionFusion() override;
+    virtual void readVehicleSpeedForPositionFusion();
 
 signals:
     void updatedGNSSPositionAndYaw(QSharedPointer<VehicleState> vehicleState, double distanceMoved, bool fused);

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -44,7 +44,7 @@ protected:
 
 private:
     bool configureUblox();
-    void updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt);
+    void updateGNSSPositionAndOrientation(const ubx_nav_pvt &pvt);
     void restoreBackedupConfiguration(int pollIntervalms = 1000, int maxPolls = 10);
     void createConfigurationBackup(int pollIntervalms = 1000, int maxPolls = 10);
     bool switchNavPrioMode(bool navPrioMode);

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -29,6 +29,7 @@ public:
     void setForceRecalibrateSensors(bool forceRecalibrateSensors) { mCalibrateEsfSensors = forceRecalibrateSensors; }
     void setNavPvtMessageRate(int rate) { mNavPvtMessageRate = rate; }
     void setSpeedDataInputRate(int rate) { mSpeedDataInputRate = rate; }
+    void setFusionOnChip(bool fusionOnChip) { mFusionOnChip = fusionOnChip; }
     void setPrintVerbose(bool printVerbose) { mPrintVerbose = printVerbose; }
     void setESFAlgAutoMntAlgOn(bool esfAlgAutoMntAlgOn) { mESFAlgAutoMntAlgOn = esfAlgAutoMntAlgOn; }
     virtual void aboutToShutdown() override;
@@ -54,12 +55,11 @@ private:
     DynamicModel mDynamicModel = DynamicModel::AUTOMOT;
     int mNavPvtMessageRate = 5; // Hz
     int mSpeedDataInputRate = 10; // Hz
+    bool mFusionOnChip = true; // only used for Ublox F9R
     bool mCalibrateEsfSensors = false;
     bool mESFAlgAutoMntAlgOn = false;
     bool mPrintVerbose = false;
     bool mCreateBackupWithSoS = false;
-
-
 };
 
 #endif // UBLOXROVER_H

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -36,7 +36,6 @@ public:
     virtual void readObjectSpeedForPositionFusion();
 
 signals:
-    void updatedGNSSPositionAndYaw(QSharedPointer<ObjectState> objectState, double distanceMoved, bool fused);
     void txNavPvt(const ubx_nav_pvt &pvt);
     void gotNmeaGga(const QByteArray& nmeaGgaStr);
 

--- a/sensors/gnss/ubloxrover.h
+++ b/sensors/gnss/ubloxrover.h
@@ -27,8 +27,7 @@ public:
     void writeOdomToUblox(ubx_esf_datatype_enum dataType, uint32_t dataField, uint32_t timeTag = 0);
     void setDynamicModel(DynamicModel dynamicModel) { mDynamicModel = dynamicModel; }
     void setForceRecalibrateSensors(bool forceRecalibrateSensors) { mCalibrateEsfSensors = forceRecalibrateSensors; }
-    void setGNSSMeasurementRate(int rate) { mGNSSMeasurementRate = rate; }
-    void setNavPrioMessageRate(int rate) { mNavPrioMessageRate = rate; }
+    void setNavPvtMessageRate(int rate) { mNavPvtMessageRate = rate; }
     void setSpeedDataInputRate(int rate) { mSpeedDataInputRate = rate; }
     void setPrintVerbose(bool printVerbose) { mPrintVerbose = printVerbose; }
     void setESFAlgAutoMntAlgOn(bool esfAlgAutoMntAlgOn) { mESFAlgAutoMntAlgOn = esfAlgAutoMntAlgOn; }
@@ -53,8 +52,7 @@ private:
     Ublox mUblox;
 
     DynamicModel mDynamicModel = DynamicModel::AUTOMOT;
-    int mGNSSMeasurementRate = 1; // Hz
-    int mNavPrioMessageRate = 10; // Hz
+    int mNavPvtMessageRate = 5; // Hz
     int mSpeedDataInputRate = 10; // Hz
     bool mCalibrateEsfSensors = false;
     bool mESFAlgAutoMntAlgOn = false;

--- a/sensors/imu/bno055orientationupdater.cpp
+++ b/sensors/imu/bno055orientationupdater.cpp
@@ -5,7 +5,7 @@
 #include "bno055orientationupdater.h"
 #include <QDebug>
 
-BNO055OrientationUpdater::BNO055OrientationUpdater(QSharedPointer<VehicleState> vehicleState, QString i2cBus) : IMUOrientationUpdater(vehicleState)
+BNO055OrientationUpdater::BNO055OrientationUpdater(QSharedPointer<ObjectState> objectState, QString i2cBus) : IMUOrientationUpdater(objectState)
 {
     int res = get_i2cbus(i2cBus.toLocal8Bit().data(), mBNO055I2CAddress.toLocal8Bit().data());
 
@@ -26,14 +26,14 @@ BNO055OrientationUpdater::BNO055OrientationUpdater(QSharedPointer<VehicleState> 
                 qDebug() << "WARNING: BNO055OrientationUpdater cannot read orientation data from i2c bus.";
             } else {
                 // qDebug() << "Roll:" << bnod.eul_roll << "Pitch:" << bnod.eul_pitc << "Yaw:" << bnod.eul_head;
-                QSharedPointer<VehicleState> vehicleState = getVehicleState();
-                PosPoint currIMUPos = vehicleState->getPosition(PosType::IMU);
+                QSharedPointer<ObjectState> objectState = getObjectState();
+                PosPoint currIMUPos = objectState->getPosition(PosType::IMU);
 
                 currIMUPos.setRollPitchYaw(bnod.eul_roll, bnod.eul_pitc, coordinateTransforms::yawNEDtoENU(bnod.eul_head));
                 currIMUPos.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
-                vehicleState->setPosition(currIMUPos);
+                objectState->setPosition(currIMUPos);
 
-                emit updatedIMUOrientation(vehicleState);
+                emit updatedIMUOrientation(objectState);
             }
         });
         mPollTimer.start(mPollIntervall_ms);

--- a/sensors/imu/bno055orientationupdater.h
+++ b/sensors/imu/bno055orientationupdater.h
@@ -18,10 +18,10 @@ extern "C" {
 class BNO055OrientationUpdater : public IMUOrientationUpdater
 {
 public:
-    BNO055OrientationUpdater(QSharedPointer<VehicleState> vehicleState, QString i2cBus = "/dev/i2c-1");
+    BNO055OrientationUpdater(QSharedPointer<ObjectState> objectState, QString i2cBus = "/dev/i2c-1");
     void printBNO055Info();
 
-    virtual bool setUpdateIntervall(int pollIntervall_ms) override;
+    bool setUpdateIntervall(int pollIntervall_ms);
 
 private:
     const QString mBNO055I2CAddress = "0x28";

--- a/sensors/imu/imuorientationupdater.cpp
+++ b/sensors/imu/imuorientationupdater.cpp
@@ -4,12 +4,43 @@
  */
 #include "imuorientationupdater.h"
 
-IMUOrientationUpdater::IMUOrientationUpdater(QSharedPointer<VehicleState> vehicleState)
+IMUOrientationUpdater::IMUOrientationUpdater(QSharedPointer<ObjectState> objectState)
 {
-    mVehicleState = vehicleState;
+    mObjectState = objectState;
 }
 
-QSharedPointer<VehicleState> IMUOrientationUpdater::getVehicleState() const
+QSharedPointer<ObjectState> IMUOrientationUpdater::getObjectState() const
 {
-    return mVehicleState;
+    return mObjectState;
+}
+
+void IMUOrientationUpdater::simulationStep(const std::function<void(QTime, QSharedPointer<ObjectState>)> &simulationFn)
+{
+    static PosPoint lastOdomPosPoint = PosPoint();
+    PosPoint odomPosPoint = mObjectState->getPosition(PosType::odom);
+
+    if (simulationFn) {
+        simulationFn(odomPosPoint.getTime(), mObjectState);
+    } else {
+        double deltaX = odomPosPoint.getX() - lastOdomPosPoint.getX();
+        double deltaY = odomPosPoint.getY() - lastOdomPosPoint.getY();
+        double deltaYaw = odomPosPoint.getYaw() - lastOdomPosPoint.getYaw();
+
+        PosPoint imuPosPoint = mObjectState->getPosition(PosType::IMU);
+        imuPosPoint.setX(imuPosPoint.getX() + deltaX);
+        imuPosPoint.setY(imuPosPoint.getY() + deltaY);
+        double yawResult = imuPosPoint.getYaw() + deltaYaw;
+
+        while (yawResult < -180.0)
+            yawResult += 360.0;
+        while (yawResult >= 180.0)
+            yawResult -= 360.0;
+
+        imuPosPoint.setYaw(yawResult);
+        imuPosPoint.setTime(odomPosPoint.getTime());
+        mObjectState->setPosition(imuPosPoint);
+    }
+
+    emit updatedIMUOrientation(mObjectState);
+    lastOdomPosPoint = odomPosPoint;
 }

--- a/sensors/imu/imuorientationupdater.h
+++ b/sensors/imu/imuorientationupdater.h
@@ -10,22 +10,22 @@
 
 #include <QObject>
 #include <QSharedPointer>
-#include "vehicles/vehiclestate.h"
+#include "vehicles/objectstate.h"
 
 class IMUOrientationUpdater : public QObject
 {
     Q_OBJECT
 public:
-    IMUOrientationUpdater(QSharedPointer<VehicleState> vehicleState);
-    QSharedPointer<VehicleState> getVehicleState() const;
-    virtual bool setUpdateIntervall(int intervall_ms) = 0;
+    IMUOrientationUpdater(QSharedPointer<ObjectState> objectState);
+    QSharedPointer<ObjectState> getObjectState() const;
+    void simulationStep(const std::function<void(QTime, QSharedPointer<ObjectState>)> &simulationFn = nullptr);
 
 
 signals:
-    void updatedIMUOrientation(QSharedPointer<VehicleState> vehicleState);
+    void updatedIMUOrientation(QSharedPointer<ObjectState> objectState);
 
 private:
-    QSharedPointer<VehicleState> mVehicleState; // vehicle which's PosType::IMU is periodically updated
+    QSharedPointer<ObjectState> mObjectState; // object whose PosType::IMU is periodically updated
 
 };
 

--- a/userinterface/flyui.cpp
+++ b/userinterface/flyui.cpp
@@ -254,10 +254,12 @@ void FlyUI::updateVehicleIdToFollow(int index)
 
     QSharedPointer<VehicleState> vehicleState = ui->followVehicleIdCombo->itemData(index).value<QSharedPointer<MavsdkVehicleConnection>>()->getVehicleState();
 
-    connect(vehicleState.get(), &ObjectState::positionUpdated, this, [this, vehicleState](){
-        auto positionOfVehicleToFollow = vehicleState->getPosition();
-        positionOfVehicleToFollow.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
-        if (mCurrentVehicleConnection)
-            mCurrentVehicleConnection->updatePointToFollowInEnuFrame(positionOfVehicleToFollow);
+    connect(vehicleState.get(), &ObjectState::positionUpdated, this, [this, vehicleState](PosType type) {
+        if (type == PosType::fused) {
+            auto positionOfVehicleToFollow = vehicleState->getPosition();
+            positionOfVehicleToFollow.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
+            if (mCurrentVehicleConnection)
+                mCurrentVehicleConnection->updatePointToFollowInEnuFrame(positionOfVehicleToFollow);
+        }
     }, Qt::QueuedConnection);
 }

--- a/userinterface/map/mapwidget.cpp
+++ b/userinterface/map/mapwidget.cpp
@@ -57,7 +57,11 @@ MapWidget::MapWidget(QWidget *parent) : QWidget(parent)
 void MapWidget::addObjectState(QSharedPointer<ObjectState> objectState)
 {
     mObjectStateMap.insert(objectState->getId(), objectState);
-    connect(objectState.get(), &ObjectState::positionUpdated, this, &MapWidget::triggerUpdate);
+    QMetaObject::Connection conn = connect(objectState.get(), &ObjectState::positionUpdated, [this](PosType type){
+        Q_UNUSED(type);
+        triggerUpdate();
+    });
+    mObjectStateConnectionMap.insert(objectState->getId(), conn);
 }
 
 QSharedPointer<ObjectState> MapWidget::getObjectState(int objectID)
@@ -67,7 +71,8 @@ QSharedPointer<ObjectState> MapWidget::getObjectState(int objectID)
 
 bool MapWidget::removeObjectState(int objectID)
 {
-    QObject::disconnect(mObjectStateMap.value(objectID).get(), &ObjectState::positionUpdated, this, &MapWidget::triggerUpdate);
+    disconnect(mObjectStateConnectionMap.value(objectID));
+    mObjectStateConnectionMap.remove(objectID);
 
     bool removedAnElement = mObjectStateMap.remove(objectID);
     update();

--- a/userinterface/map/mapwidget.h
+++ b/userinterface/map/mapwidget.h
@@ -121,6 +121,7 @@ protected:
 
 private:
     QMap<int, QSharedPointer<ObjectState>> mObjectStateMap;
+    QMap<int, QMetaObject::Connection> mObjectStateConnectionMap;
     llh_t mRefLlh;
     double mScaleFactor;
     double mRotation;

--- a/vehicles/controller/vescmotorcontroller.cpp
+++ b/vehicles/controller/vescmotorcontroller.cpp
@@ -134,9 +134,9 @@ QSharedPointer<ServoController> VESCMotorController::getServoController()
     return mVESCServoController;
 }
 
-QSharedPointer<IMUOrientationUpdater> VESCMotorController::getIMUOrientationUpdater(QSharedPointer<VehicleState> vehicleState)
+QSharedPointer<IMUOrientationUpdater> VESCMotorController::getIMUOrientationUpdater(QSharedPointer<ObjectState> objectState)
 {
-    mVESCOrientationUpdater.reset(new VESCOrientationUpdater(vehicleState));
+    mVESCOrientationUpdater.reset(new VESCOrientationUpdater(objectState));
     setEnableIMUOrientationUpdate(true);
 
     return  mVESCOrientationUpdater;

--- a/vehicles/controller/vescmotorcontroller.h
+++ b/vehicles/controller/vescmotorcontroller.h
@@ -34,7 +34,7 @@ public:
 
 
     QSharedPointer<ServoController> getServoController();
-    QSharedPointer<IMUOrientationUpdater> getIMUOrientationUpdater(QSharedPointer<VehicleState> vehicleState);
+    QSharedPointer<IMUOrientationUpdater> getIMUOrientationUpdater(QSharedPointer<ObjectState> objectState);
 
     int getPollValuesPeriod() const;
     void setPollValuesPeriod(int milliseconds);
@@ -52,20 +52,17 @@ private:
 
     class VESCOrientationUpdater : public IMUOrientationUpdater {
     public:
-        VESCOrientationUpdater(QSharedPointer<VehicleState> vehicleState) : IMUOrientationUpdater(vehicleState) {}
-        virtual bool setUpdateIntervall(int) override {
-            return false; // TODO
-        }
+        VESCOrientationUpdater(QSharedPointer<ObjectState> objectState) : IMUOrientationUpdater(objectState) {}
     private:
         void useIMUDataFromVESC(double roll, double pitch, double yaw) {
-            QSharedPointer<VehicleState> vehicleState = getVehicleState();
-            PosPoint currIMUPos = vehicleState->getPosition(PosType::IMU);
+            QSharedPointer<ObjectState> objectState = getObjectState();
+            PosPoint currIMUPos = objectState->getPosition(PosType::IMU);
 
             currIMUPos.setRollPitchYaw(roll, pitch, coordinateTransforms::yawNEDtoENU(yaw));
             currIMUPos.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
-            vehicleState->setPosition(currIMUPos);
+            objectState->setPosition(currIMUPos);
 
-            emit updatedIMUOrientation(vehicleState);
+            emit updatedIMUOrientation(objectState);
         };
 
         friend class VESCMotorController;

--- a/vehicles/objectstate.cpp
+++ b/vehicles/objectstate.cpp
@@ -11,6 +11,18 @@ ObjectState::ObjectState(ObjectID_t id, Qt::GlobalColor color)
 {
     setId(id, true);
     setColor(color);
+    mTime = QTime();
+
+    for (int i = 0; i < (int)PosType::_LAST_; i++)
+        switch((PosType) i) {
+            case PosType::simulated: mPositionBySource[i].setType(PosType::simulated); break;
+            case PosType::fused: mPositionBySource[i].setType(PosType::fused); break;
+            case PosType::odom: mPositionBySource[i].setType(PosType::odom); break;
+            case PosType::IMU: mPositionBySource[i].setType(PosType::IMU); break;
+            case PosType::GNSS: mPositionBySource[i].setType(PosType::GNSS); break;
+            case PosType::UWB: mPositionBySource[i].setType(PosType::UWB); break;
+            case PosType::_LAST_: qDebug() << "This should not have happended."; break;
+        }
 }
 
 void ObjectState::setId(int id, bool changeName)
@@ -25,8 +37,9 @@ void ObjectState::setId(int id, bool changeName)
 
 void ObjectState::setPosition(PosPoint &point)
 {
-    mPosition = point;
-    emit positionUpdated();
+    mPositionBySource[(int)point.getType()] = point;
+
+    emit positionUpdated(point.getType());
 }
 
 void ObjectState::setDrawStatusText(bool drawStatusText)
@@ -37,4 +50,9 @@ void ObjectState::setDrawStatusText(bool drawStatusText)
 bool ObjectState::getDrawStatusText() const
 {
     return mDrawStatusText;
+}
+
+PosPoint ObjectState::getPosition(PosType type) const
+{
+    return mPositionBySource[(int)type];
 }

--- a/vehicles/objectstate.cpp
+++ b/vehicles/objectstate.cpp
@@ -56,3 +56,15 @@ PosPoint ObjectState::getPosition(PosType type) const
 {
     return mPositionBySource[(int)type];
 }
+
+void ObjectState::setEnuRef(llh_t enuRef)
+{
+    mEnuReference = enuRef;
+    mEnuReferenceSet = true;
+    emit updatedEnuReference(mEnuReference);
+}
+
+bool ObjectState::isEnuReferenceSet()
+{
+    return mEnuReferenceSet;
+}

--- a/vehicles/objectstate.h
+++ b/vehicles/objectstate.h
@@ -52,6 +52,10 @@ public:
     WAYWISE_OBJECT_TYPE getWaywiseObjectType() const { return mWaywiseObjectType; }
     void setWaywiseObjectType(const WAYWISE_OBJECT_TYPE value) { mWaywiseObjectType = value; }
 
+    virtual llh_t getEnuRef() const { return mEnuReference; }
+    virtual void setEnuRef(llh_t enuRef);
+    bool isEnuReferenceSet();
+
     // Dynamic state
     virtual PosPoint getPosition(PosType type) const;
     virtual PosPoint getPosition() const { return getPosition(PosType::simulated); }
@@ -70,6 +74,7 @@ public:
 
 signals:
     void positionUpdated(PosType type);
+    void updatedEnuReference(llh_t mEnuReference);
 
 private:
     // Static state
@@ -78,6 +83,9 @@ private:
     Qt::GlobalColor mColor;
     bool mDrawStatusText = true;
     WAYWISE_OBJECT_TYPE mWaywiseObjectType = WAYWISE_OBJECT_TYPE_GENERIC;
+
+    llh_t mEnuReference = {57.71495867, 12.89134921, 0}; // AztaZero {57.7810, 12.7692, 0}, Klätterlabbet {57.6876, 11.9807, 0}, RISE RTK base station {57.71495867, 12.89134921, 0}
+    bool mEnuReferenceSet = false;
 
 protected:
     // Dynamic state

--- a/vehicles/objectstate.h
+++ b/vehicles/objectstate.h
@@ -53,10 +53,11 @@ public:
     void setWaywiseObjectType(const WAYWISE_OBJECT_TYPE value) { mWaywiseObjectType = value; }
 
     // Dynamic state
-    virtual PosPoint getPosition() const { return mPosition; }
+    virtual PosPoint getPosition(PosType type) const;
+    virtual PosPoint getPosition() const { return getPosition(PosType::simulated); }
     virtual void setPosition(PosPoint &point);
-    virtual QTime getTime() const { return mPosition.getTime(); }
-    virtual void setTime(const QTime &time) { mPosition.setTime(time); }
+    virtual QTime getTime() const { return mTime; }
+    virtual void setTime(const QTime &time) { mTime = time; }
     virtual double getSpeed() const { return mSpeed; }
     virtual void setSpeed(double value) { mSpeed = value; }
     virtual Velocity getVelocity() const { return mVelocity; }
@@ -68,7 +69,7 @@ public:
     bool getDrawStatusText() const;
 
 signals:
-    void positionUpdated();
+    void positionUpdated(PosType type);
 
 private:
     // Static state
@@ -80,10 +81,11 @@ private:
 
 protected:
     // Dynamic state
-    PosPoint mPosition;
+    QTime mTime;
     double mSpeed = 0.0; // [m/s]
     Velocity mVelocity = {0.0, 0.0, 0.0}; // [m/s]
     Acceleration mAcceleration = {0.0, 0.0, 0.0}; // [m/s²]
+    PosPoint mPositionBySource[(int)PosType::_LAST_];
 };
 
 

--- a/vehicles/vehiclestate.cpp
+++ b/vehicles/vehiclestate.cpp
@@ -8,27 +8,6 @@
 VehicleState::VehicleState(ObjectID_t id, Qt::GlobalColor color)
     : ObjectState (id, color)
 {
-    mTime = QTime();
-
-    for (int i = 0; i < (int)PosType::_LAST_; i++)
-        switch((PosType) i) {
-        case PosType::simulated: mPositionBySource[i].setType(PosType::simulated); break;
-        case PosType::fused: mPositionBySource[i].setType(PosType::fused); break;
-        case PosType::odom: mPositionBySource[i].setType(PosType::odom); break;
-        case PosType::IMU: mPositionBySource[i].setType(PosType::IMU); break;
-        case PosType::GNSS: mPositionBySource[i].setType(PosType::GNSS); break;
-        case PosType::UWB: mPositionBySource[i].setType(PosType::UWB); break;
-        case PosType::_LAST_: qDebug() << "This should not have happended."; break;
-
-        }
-}
-
-
-void VehicleState::setPosition(PosPoint &point)
-{
-    mPositionBySource[(int)point.getType()] = point;
-
-    emit positionUpdated();
 }
 
 std::array<float, 3> VehicleState::getGyroscopeXYZ() const
@@ -82,11 +61,6 @@ bool VehicleState::getIsArmed() const
 void VehicleState::setIsArmed(bool isArmed)
 {
     mIsArmed = isArmed;
-}
-
-PosPoint VehicleState::getPosition(PosType type) const
-{
-    return mPositionBySource[(int)type];
 }
 
 PosPoint VehicleState::posInVehicleFrameToPosPointENU(xyz_t offset, PosType type) const

--- a/vehicles/vehiclestate.cpp
+++ b/vehicles/vehiclestate.cpp
@@ -120,15 +120,3 @@ bool VehicleState::hasTrailingVehicle() const
 {
     return !mTrailingVehicle.isNull();
 }
-
-void VehicleState::setEnuRef(llh_t enuRef)
-{
-    mEnuReference = enuRef;
-    mEnuReferenceSet = true;
-    emit updatedEnuReference(mEnuReference);
-}
-
-bool VehicleState::isEnuReferenceSet()
-{
-    return mEnuReferenceSet;
-}

--- a/vehicles/vehiclestate.h
+++ b/vehicles/vehiclestate.h
@@ -57,10 +57,6 @@ public:
     double getMaxAcceleration() const { return mMaxAcceleration; }
     void setMaxAcceleration(double maxAcceleration) { mMaxAcceleration = maxAcceleration; }
 
-    virtual llh_t getEnuRef() const { return mEnuReference; }
-    virtual void setEnuRef(llh_t enuRef);
-    bool isEnuReferenceSet();
-
     xyz_t getRearAxleToCenterOffset() const { return mRearAxleToCenterOffset; }
     void setRearAxleToCenterOffset(double rearAxleToCenterOffsetX) { mRearAxleToCenterOffset.x = rearAxleToCenterOffsetX; }
     void setRearAxleToCenterOffset(xyz_t rearAxleToCenterOffset) { mRearAxleToCenterOffset = rearAxleToCenterOffset; }
@@ -106,9 +102,6 @@ public:
     std::array<float, 3> getAccelerometerXYZ() const;
     void setAccelerometerXYZ(const std::array<float, 3> &accelerometerXYZ);
 
-signals:
-    void updatedEnuReference(llh_t mEnuReference);
-
 private:
     // Static state
     double mLength = 0.8; // [m]
@@ -120,9 +113,6 @@ private:
     xyz_t mRearAxleToCenterOffset;
     xyz_t mRearAxleToRearEndOffset{-0.1333, 0.0, 0.0};
     xyz_t mRearAxleToHitchOffset;
-
-    llh_t mEnuReference = {57.71495867, 12.89134921, 0}; // AztaZero {57.7810, 12.7692, 0}, Klätterlabbet {57.6876, 11.9807, 0}, RISE RTK base station {57.71495867, 12.89134921, 0}
-    bool mEnuReferenceSet = false;
 
     // Dynamic state
     double mSteering = 0.0; // [-1.0:1.0]

--- a/vehicles/vehiclestate.h
+++ b/vehicles/vehiclestate.h
@@ -72,13 +72,8 @@ public:
     void setRearAxleToHitchOffset(xyz_t rearAxleToHitchOffset) { mRearAxleToHitchOffset = rearAxleToHitchOffset; }
 
     // Dynamic state
-    virtual PosPoint getPosition(PosType type) const;
-    virtual PosPoint getPosition() const override { return getPosition(PosType::simulated); }
     virtual PosPoint posInVehicleFrameToPosPointENU(xyz_t offset, PosType type) const;
     virtual PosPoint posInVehicleFrameToPosPointENU(xyz_t offset) const { return posInVehicleFrameToPosPointENU(offset, PosType::simulated); }
-    virtual void setPosition(PosPoint &point) override;
-    virtual QTime getTime() const override { return mTime; }
-    virtual void setTime(const QTime &time) override { mTime = time; }
     FlightMode getFlightMode() const;
     void setFlightMode(const FlightMode &flightMode);
     double getSteering() const;
@@ -131,9 +126,7 @@ private:
 
     // Dynamic state
     double mSteering = 0.0; // [-1.0:1.0]
-    PosPoint mPositionBySource[(int)PosType::_LAST_];
     PosPoint mApGoal;
-    QTime mTime;
     PosPoint mHomePosition;
     bool mIsArmed = false;
     FlightMode mFlightMode = FlightMode::Unknown;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

> Refactoring / Feature enhancement - Architecture improvement for GNSS positioning system

* **What is the current behavior?** (You can also link to an open issue here)
> - Position-related functionality is tightly coupled to VehicleState
> - GNSS position update logic is embedded within UbloxRover
> - Limited flexibility for working with multiple objects or non-vehicle entities

* **What is the new behavior (if this is a feature change)?**
> - GnssFixStatus struct in GNSSReceiver base class for comprehensive GNSS position information
> - Base updateGNSSPositionAndYaw() function in GNSSReceiver for consistent signal emission
> -  ObjectState updates:
    - Moves positionBySource from VehicleState to ObjectState
    - Moves enuRef (ENU reference) from VehicleState to ObjectState
    - Updates PositionFuser to work with ObjectState
    - Allows ImuOrientationUpdater to be created with ObjectState
> - Cleans up UbloxRover implementation


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

> Yes, some function names are updated in UbloxRover, GNSSReceiver, and sdvp position fuser. So any downstream applications using these classes should update the calls accordingly.


