### PR TITLE
Copter waypoint follower

### DIFF
--- a/autopilot/copterwaypointfollower.cpp
+++ b/autopilot/copterwaypointfollower.cpp
@@ -13,6 +13,70 @@
 
 namespace {
 constexpr double kDegToRad = M_PI / 180.0;
+constexpr double kVerticalLegHorizontalSpeedThreshold = 0.15;
+
+double controlledVerticalSpeed(
+    double heightError,
+    double verticalVelocity,
+    double maxVerticalSpeed,
+    double dt,
+    double heightTolerance,
+    double proportionalGain,
+    double integralGain,
+    double derivativeGain,
+    double integralLimit,
+    double &heightErrorIntegral)
+{
+    if (maxVerticalSpeed <= std::numeric_limits<double>::epsilon()) {
+        return 0.0;
+    }
+
+    if (std::abs(heightError) <= heightTolerance) {
+        heightErrorIntegral = 0.0;
+        return 0.0;
+    }
+
+    heightErrorIntegral = std::clamp(
+        heightErrorIntegral + heightError * dt,
+        -integralLimit,
+        integralLimit);
+
+    const double verticalSpeed =
+        proportionalGain * heightError +
+        integralGain * heightErrorIntegral -
+        derivativeGain * verticalVelocity;
+    return std::clamp(verticalSpeed, -maxVerticalSpeed, maxVerticalSpeed);
+}
+
+double verticalSpeedForHeightError(
+    double heightError,
+    double verticalVelocity,
+    double verticalSpeedLimit,
+    double dt,
+    double heightTolerance,
+    double proportionalGain,
+    double integralGain,
+    double derivativeGain,
+    double integralLimit,
+    double &heightErrorIntegral)
+{
+    if (heightError < -heightTolerance) {
+        heightErrorIntegral = 0.0;
+        return -verticalSpeedLimit;
+    }
+
+    return controlledVerticalSpeed(
+        heightError,
+        verticalVelocity,
+        verticalSpeedLimit,
+        dt,
+        heightTolerance,
+        proportionalGain,
+        integralGain,
+        derivativeGain,
+        integralLimit,
+        heightErrorIntegral);
+}
 }
 
 CopterWaypointFollower::CopterWaypointFollower(
@@ -73,17 +137,22 @@ void CopterWaypointFollower::startFollowingRoute(bool fromBeginning)
 
     emit activateEmergencyBrake();
 
+    mCurrentState.currentWaypointIndex = fromBeginning ? 0 : findClosestSegmentStartIndex();
+    mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_INIT;
+    mSkipStartWaypointAfterClimb = false;
+    mClimbingToStartWaypointHeight = !fromBeginning;
     if (fromBeginning) {
-        mCurrentState.currentWaypointIndex = 0;
-        mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_INIT;
-    } else {
-        mCurrentState.currentWaypointIndex = findClosestWaypointIndex();
-        mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
-        mCurrentState.stmState =
-            mCurrentState.currentWaypointIndex == mWaypointList.size() - 1 ?
-            WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL :
-            WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
+        const PosPoint currentPos = getCurrentVehiclePosition();
+        const PosPoint startWaypoint = mWaypointList.first();
+        const double dx = startWaypoint.getX() - currentPos.getX();
+        const double dy = startWaypoint.getY() - currentPos.getY();
+        const double distance2d = std::sqrt(dx * dx + dy * dy);
+        mClimbingToStartWaypointHeight = distance2d <= mWaypointProximity &&
+            std::abs(startWaypoint.getHeight() - currentPos.getHeight()) > mVerticalHeightTolerance;
+        mSkipStartWaypointAfterClimb = mClimbingToStartWaypointHeight;
     }
+    mPrevDistanceToGoal = std::numeric_limits<double>::max();
+    mVerticalHeightErrorIntegral = 0.0;
 
     mUpdateStateTimer.start(mUpdateStatePeriod_ms);
 }
@@ -108,7 +177,10 @@ void CopterWaypointFollower::resetState()
     mCurrentState.stmState = WayPointFollowerSTMstates::NONE;
     mCurrentState.currentWaypointIndex = mWaypointList.size();
     mCurrentState.currentGoal = PosPoint();
+    mClimbingToStartWaypointHeight = false;
+    mSkipStartWaypointAfterClimb = false;
     mPrevDistanceToGoal = std::numeric_limits<double>::max();
+    mVerticalHeightErrorIntegral = 0.0;
     holdPosition();
 }
 
@@ -134,12 +206,92 @@ void CopterWaypointFollower::updateState()
             mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FINISHED;
             break;
         }
+
+        if (mClimbingToStartWaypointHeight) {
+            if (mCurrentState.currentWaypointIndex >= mWaypointList.size()) {
+                mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
+            }
+            mCurrentState.currentGoal = waypointHeightAtCurrentPosition(
+                mCurrentState.currentWaypointIndex);
+            const double heightError =
+                mCurrentState.currentGoal.getHeight() - getCurrentVehiclePosition().getHeight();
+            if (std::abs(heightError) > mVerticalHeightTolerance) {
+                updateClimbControl(mCurrentState.currentGoal);
+                break;
+            }
+
+            mClimbingToStartWaypointHeight = false;
+            mDesiredVelocityCommand = {};
+            mPrevDistanceToGoal = std::numeric_limits<double>::max();
+            mVerticalHeightErrorIntegral = 0.0;
+            if (mSkipStartWaypointAfterClimb &&
+                mCurrentState.currentWaypointIndex + 1 < mWaypointList.size()) {
+                mCurrentState.currentWaypointIndex++;
+            }
+            mSkipStartWaypointAfterClimb = false;
+            mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+            const PosPoint currentPos = getCurrentVehiclePosition();
+            const double dx = mCurrentState.currentGoal.getX() - currentPos.getX();
+            const double dy = mCurrentState.currentGoal.getY() - currentPos.getY();
+            const double distance2d = std::sqrt(dx * dx + dy * dy);
+            if (distance2d <= mWaypointProximity &&
+                mCurrentState.currentWaypointIndex + 1 < mWaypointList.size()) {
+                mCurrentState.currentWaypointIndex++;
+                mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+            }
+            mCurrentState.stmState =
+                mCurrentState.currentWaypointIndex == mWaypointList.size() - 1 ?
+                WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL :
+                WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
+            updateControl(mCurrentState.currentGoal);
+            break;
+        }
+
         mCurrentState.currentWaypointIndex = 0;
         mCurrentState.currentGoal = mWaypointList.at(0);
         mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_GOTO_BEGIN;
         break;
 
-    case WayPointFollowerSTMstates::FOLLOW_ROUTE_GOTO_BEGIN:
+    case WayPointFollowerSTMstates::FOLLOW_ROUTE_GOTO_BEGIN: {
+        if (mCurrentState.currentWaypointIndex >= mWaypointList.size()) {
+            mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
+            mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL;
+            mPrevDistanceToGoal = std::numeric_limits<double>::max();
+            break;
+        }
+
+        mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+        const double distanceToGoal =
+            getCurrentVehiclePosition().getDistanceTo3d(mCurrentState.currentGoal);
+        const PosPoint currentPos = getCurrentVehiclePosition();
+        const double dx = mCurrentState.currentGoal.getX() - currentPos.getX();
+        const double dy = mCurrentState.currentGoal.getY() - currentPos.getY();
+        const double dz = mCurrentState.currentGoal.getHeight() - currentPos.getHeight();
+        const double distance2d = std::sqrt(dx * dx + dy * dy);
+
+        const bool reachedByProximity = distanceToGoal <= mWaypointProximity ||
+            (distance2d <= mWaypointProximity && std::abs(dz) <= mVerticalHeightTolerance);
+        const bool reachedByOvershoot = mPrevDistanceToGoal <= mWaypointProximity * 2.0
+                                        && distanceToGoal > mPrevDistanceToGoal;
+        if (reachedByProximity || reachedByOvershoot) {
+            mPrevDistanceToGoal = std::numeric_limits<double>::max();
+            mCurrentState.currentWaypointIndex++;
+            if (mCurrentState.currentWaypointIndex >= mWaypointList.size()) {
+                mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
+                mCurrentState.currentGoal = mWaypointList.last();
+                mCurrentState.stmState =
+                    WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL;
+            } else {
+                mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+                mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
+            }
+        } else {
+            mPrevDistanceToGoal = distanceToGoal;
+        }
+
+        updateControl(mCurrentState.currentGoal);
+    } break;
+
     case WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING: {
         if (mCurrentState.currentWaypointIndex >= mWaypointList.size()) {
             mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
@@ -151,10 +303,16 @@ void CopterWaypointFollower::updateState()
         mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
         const double distanceToGoal =
             getCurrentVehiclePosition().getDistanceTo3d(mCurrentState.currentGoal);
+        const PosPoint currentPos = getCurrentVehiclePosition();
+        const double dx = mCurrentState.currentGoal.getX() - currentPos.getX();
+        const double dy = mCurrentState.currentGoal.getY() - currentPos.getY();
+        const double dz = mCurrentState.currentGoal.getHeight() - currentPos.getHeight();
+        const double distance2d = std::sqrt(dx * dx + dy * dy);
 
         // Advance if within proximity, OR if the drone overshot — it was within
         // 2× proximity at closest approach but is now moving away from the waypoint.
-        const bool reachedByProximity = distanceToGoal <= mWaypointProximity;
+        const bool reachedByProximity = distanceToGoal <= mWaypointProximity ||
+            (distance2d <= mWaypointProximity && std::abs(dz) <= mVerticalHeightTolerance);
         const bool reachedByOvershoot = mPrevDistanceToGoal <= mWaypointProximity * 2.0
                                         && distanceToGoal > mPrevDistanceToGoal;
         if (reachedByProximity || reachedByOvershoot) {
@@ -212,15 +370,64 @@ void CopterWaypointFollower::updateControl(const PosPoint &goal)
     const PosPoint currentPos = getCurrentVehiclePosition();
     const double dx = goal.getX() - currentPos.getX();
     const double dy = goal.getY() - currentPos.getY();
+    const double distance2d = std::sqrt(dx * dx + dy * dy);
+
+    if (isVerticalLeg(mCurrentState.currentWaypointIndex)) {
+        const auto velocity = mVehicleState->getVelocity();
+        const double horizontalSpeed = std::hypot(velocity.x, velocity.y);
+        const double horizontalSpeedTolerance = std::max(
+            kVerticalLegHorizontalSpeedThreshold,
+            mMinApproachSpeed);
+        if (distance2d > mWaypointProximity ||
+            horizontalSpeed > horizontalSpeedTolerance) {
+            PosPoint levelGoal = goal;
+            levelGoal.setHeight(verticalLegReferenceHeight(mCurrentState.currentWaypointIndex));
+            updateTrackingControl(levelGoal);
+        } else {
+            updateClimbControl(goal);
+        }
+        return;
+    }
+
+    updateTrackingControl(goal);
+}
+
+void CopterWaypointFollower::updateTrackingControl(const PosPoint &goal)
+{
+    const PosPoint currentPos = getCurrentVehiclePosition();
+    const double dx = goal.getX() - currentPos.getX();
+    const double dy = goal.getY() - currentPos.getY();
     const double dz = goal.getHeight() - currentPos.getHeight();
-    const double distance = std::sqrt(dx * dx + dy * dy + dz * dz);
+    const double distance2d = std::sqrt(dx * dx + dy * dy);
+    const double distance = std::sqrt(distance2d * distance2d + dz * dz);
+
+    if (distance2d <= mWaypointProximity && std::abs(dz) > mVerticalHeightTolerance) {
+        updateClimbControl(goal);
+        return;
+    }
 
     mDesiredVelocityCommand = {};
     if (distance > std::numeric_limits<double>::epsilon()) {
-        const double speed = speedForGoal(goal, distance);
-        const double vxEnu = dx / distance * speed;
-        const double vyEnu = dy / distance * speed;
-        const double vzEnu = dz / distance * speed;
+        const double speed = speedForGoal(goal, distance2d);
+        const double verticalSpeedLimit = dz < -mVerticalHeightTolerance ?
+            descentSpeedForGoal(goal) : speed;
+        const double vzEnu = verticalSpeedForHeightError(
+            dz,
+            mVehicleState->getVelocity().z,
+            verticalSpeedLimit,
+            mUpdateStatePeriod_ms / 1000.0,
+            mVerticalHeightTolerance,
+            mVerticalProportionalGain,
+            mVerticalIntegralGain,
+            mVerticalDerivativeGain,
+            mVerticalIntegralLimit,
+            mVerticalHeightErrorIntegral);
+        const double horizontalSpeed = distance2d > std::numeric_limits<double>::epsilon() ?
+            speed : 0.0;
+        const double vxEnu = distance2d > std::numeric_limits<double>::epsilon() ?
+            dx / distance2d * horizontalSpeed : 0.0;
+        const double vyEnu = distance2d > std::numeric_limits<double>::epsilon() ?
+            dy / distance2d * horizontalSpeed : 0.0;
         const double yawRad = currentPos.getYaw() * kDegToRad;
         const double cosYaw = std::cos(yawRad);
         const double sinYaw = std::sin(yawRad);
@@ -229,7 +436,8 @@ void CopterWaypointFollower::updateControl(const PosPoint &goal)
         mDesiredVelocityCommand.left = -vxEnu * sinYaw + vyEnu * cosYaw;
         mDesiredVelocityCommand.up = vzEnu;
 
-        const double targetYawRad = mFaceTravelDirection ?
+        const double targetYawRad = mFaceTravelDirection &&
+            distance2d > std::numeric_limits<double>::epsilon() ?
             std::atan2(dy, dx) :
             goal.getYaw() * kDegToRad;
         const double yawError = normalizeAngleRad(targetYawRad - yawRad);
@@ -243,21 +451,84 @@ void CopterWaypointFollower::updateControl(const PosPoint &goal)
 
     // Place the visual target on the approach-slowdown-radius circle facing the goal,
     // mirroring what PurePursuit does with its lookahead circle.
-    const double dist2d = std::sqrt(dx * dx + dy * dy);
-    const QPointF circleTarget = (dist2d > mApproachSlowdownRadius)
-        ? QPointF(currentPos.getX() + dx / dist2d * mApproachSlowdownRadius,
-                  currentPos.getY() + dy / dist2d * mApproachSlowdownRadius)
+    const QPointF circleTarget = (distance2d > mApproachSlowdownRadius)
+        ? QPointF(currentPos.getX() + dx / distance2d * mApproachSlowdownRadius,
+                  currentPos.getY() + dy / distance2d * mApproachSlowdownRadius)
         : goal.getPoint();
     mVehicleState->setAutopilotTargetPoint(circleTarget);
+}
+
+void CopterWaypointFollower::updateClimbControl(const PosPoint &goal)
+{
+    const PosPoint currentPos = getCurrentVehiclePosition();
+    const double heightError = goal.getHeight() - currentPos.getHeight();
+    const double verticalSpeedLimit = heightError < -mVerticalHeightTolerance ?
+        descentSpeedForGoal(goal) : speedForGoal(goal, std::abs(heightError));
+
+    mDesiredVelocityCommand = {};
+    mDesiredVelocityCommand.up = verticalSpeedForHeightError(
+        heightError,
+        mVehicleState->getVelocity().z,
+        verticalSpeedLimit,
+        mUpdateStatePeriod_ms / 1000.0,
+        mVerticalHeightTolerance,
+        mVerticalProportionalGain,
+        mVerticalIntegralGain,
+        mVerticalDerivativeGain,
+        mVerticalIntegralLimit,
+        mVerticalHeightErrorIntegral);
+
+    mMovementController->setDesiredSpeed(0.0);
+    mMovementController->setDesiredSteering(0.0);
+    mMovementController->setDesiredAttributes(goal.getAttributes());
+    mVehicleState->setAutopilotTargetPoint(currentPos.getPoint());
 }
 
 void CopterWaypointFollower::holdPosition()
 {
     mDesiredVelocityCommand = {};
+    mVerticalHeightErrorIntegral = 0.0;
     if (mMovementController) {
         mMovementController->setDesiredSpeed(0.0);
         mMovementController->setDesiredSteering(0.0);
     }
+}
+
+bool CopterWaypointFollower::isVerticalLeg(int waypointIndex) const
+{
+    if (waypointIndex <= 0 || waypointIndex >= mWaypointList.size()) {
+        return false;
+    }
+
+    const PosPoint previousGoal = mWaypointList.at(waypointIndex - 1);
+    const PosPoint goal = mWaypointList.at(waypointIndex);
+    const double dx = goal.getX() - previousGoal.getX();
+    const double dy = goal.getY() - previousGoal.getY();
+    const double dz = goal.getHeight() - previousGoal.getHeight();
+    return std::sqrt(dx * dx + dy * dy) <= mWaypointProximity &&
+        std::abs(dz) > mVerticalHeightTolerance;
+}
+
+PosPoint CopterWaypointFollower::waypointHeightAtCurrentPosition(int waypointIndex) const
+{
+    PosPoint climbGoal = mWaypointList.at(waypointIndex);
+    const PosPoint currentPos = getCurrentVehiclePosition();
+    climbGoal.setX(currentPos.getX());
+    climbGoal.setY(currentPos.getY());
+    return climbGoal;
+}
+
+double CopterWaypointFollower::verticalLegReferenceHeight(int waypointIndex) const
+{
+    if (waypointIndex <= 0 || waypointIndex >= mWaypointList.size()) {
+        return getCurrentVehiclePosition().getHeight();
+    }
+    return mWaypointList.at(waypointIndex - 1).getHeight();
+}
+
+double CopterWaypointFollower::descentSpeedForGoal(const PosPoint &) const
+{
+    return std::min(mDescentSpeed, mMaxSpeed);
 }
 
 PosPoint CopterWaypointFollower::getCurrentVehiclePosition() const
@@ -265,15 +536,37 @@ PosPoint CopterWaypointFollower::getCurrentVehiclePosition() const
     return mVehicleState->getPosition(mPosTypeUsed);
 }
 
-int CopterWaypointFollower::findClosestWaypointIndex() const
+int CopterWaypointFollower::findClosestSegmentStartIndex() const
 {
+    if (mWaypointList.size() < 2) {
+        return 0;
+    }
+
     const PosPoint currentPos = getCurrentVehiclePosition();
+    const double px = currentPos.getX();
+    const double py = currentPos.getY();
     int closestIndex = 0;
-    double closestDistance = std::numeric_limits<double>::max();
-    for (int i = 0; i < mWaypointList.size(); i++) {
-        const double distance = currentPos.getDistanceTo3d(mWaypointList.at(i));
-        if (distance < closestDistance) {
-            closestDistance = distance;
+    double closestDistanceSquared = std::numeric_limits<double>::max();
+
+    for (int i = 0; i < mWaypointList.size() - 1; i++) {
+        const PosPoint segmentStart = mWaypointList.at(i);
+        const PosPoint segmentEnd = mWaypointList.at(i + 1);
+        const double sx = segmentStart.getX();
+        const double sy = segmentStart.getY();
+        const double vx = segmentEnd.getX() - sx;
+        const double vy = segmentEnd.getY() - sy;
+        const double segmentLengthSquared = vx * vx + vy * vy;
+        const double projection = segmentLengthSquared > std::numeric_limits<double>::epsilon() ?
+            std::clamp(((px - sx) * vx + (py - sy) * vy) / segmentLengthSquared, 0.0, 1.0) :
+            0.0;
+        const double closestX = sx + projection * vx;
+        const double closestY = sy + projection * vy;
+        const double dx = px - closestX;
+        const double dy = py - closestY;
+        const double distanceSquared = dx * dx + dy * dy;
+
+        if (distanceSquared < closestDistanceSquared) {
+            closestDistanceSquared = distanceSquared;
             closestIndex = i;
         }
     }

--- a/autopilot/copterwaypointfollower.cpp
+++ b/autopilot/copterwaypointfollower.cpp
@@ -1,0 +1,310 @@
+/*
+ *     Copyright 2026 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+#include "copterwaypointfollower.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <QDebug>
+
+namespace {
+constexpr double kDegToRad = M_PI / 180.0;
+}
+
+CopterWaypointFollower::CopterWaypointFollower(
+    QSharedPointer<MovementController> movementController,
+    PosType posTypeUsed)
+{
+    mMovementController = movementController;
+    mVehicleState = mMovementController->getVehicleState();
+    mPosTypeUsed = posTypeUsed;
+    connect(&mUpdateStateTimer, &QTimer::timeout, this, &CopterWaypointFollower::updateState);
+}
+
+bool CopterWaypointFollower::getRepeatRoute() const
+{
+    return mCurrentState.repeatRoute;
+}
+
+void CopterWaypointFollower::setRepeatRoute(bool value)
+{
+    mCurrentState.repeatRoute = value;
+}
+
+const PosPoint CopterWaypointFollower::getCurrentGoal()
+{
+    return mCurrentState.currentGoal;
+}
+
+void CopterWaypointFollower::clearRoute()
+{
+    stop();
+    mWaypointList.clear();
+}
+
+void CopterWaypointFollower::addWaypoint(const PosPoint &point)
+{
+    mWaypointList.append(point);
+}
+
+void CopterWaypointFollower::addRoute(const QList<PosPoint> &route)
+{
+    if (route.isEmpty()) {
+        return;
+    }
+    mWaypointList.append(route);
+}
+
+QList<PosPoint> CopterWaypointFollower::getCurrentRoute()
+{
+    return mWaypointList;
+}
+
+void CopterWaypointFollower::startFollowingRoute(bool fromBeginning)
+{
+    if (mWaypointList.isEmpty()) {
+        qDebug() << "Note: CopterWaypointFollower does not have any waypoints to follow.";
+        return;
+    }
+
+    emit activateEmergencyBrake();
+
+    if (fromBeginning) {
+        mCurrentState.currentWaypointIndex = 0;
+        mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_INIT;
+    } else {
+        mCurrentState.currentWaypointIndex = findClosestWaypointIndex();
+        mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+        mCurrentState.stmState =
+            mCurrentState.currentWaypointIndex == mWaypointList.size() - 1 ?
+            WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL :
+            WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
+    }
+
+    mUpdateStateTimer.start(mUpdateStatePeriod_ms);
+}
+
+bool CopterWaypointFollower::isActive()
+{
+    return mUpdateStateTimer.isActive();
+}
+
+void CopterWaypointFollower::stop()
+{
+    if (mUpdateStateTimer.isActive()) {
+        mUpdateStateTimer.stop();
+    }
+    holdPosition();
+    emit deactivateEmergencyBrake();
+}
+
+void CopterWaypointFollower::resetState()
+{
+    mUpdateStateTimer.stop();
+    mCurrentState.stmState = WayPointFollowerSTMstates::NONE;
+    mCurrentState.currentWaypointIndex = mWaypointList.size();
+    mCurrentState.currentGoal = PosPoint();
+    mPrevDistanceToGoal = std::numeric_limits<double>::max();
+    holdPosition();
+}
+
+PosType CopterWaypointFollower::getPosTypeUsed() const
+{
+    return mPosTypeUsed;
+}
+
+void CopterWaypointFollower::setPosTypeUsed(const PosType &posTypeUsed)
+{
+    mPosTypeUsed = posTypeUsed;
+}
+
+void CopterWaypointFollower::updateState()
+{
+    switch (mCurrentState.stmState) {
+    case WayPointFollowerSTMstates::NONE:
+        qDebug() << "WARNING: CopterWaypointFollower running uninitialized statemachine.";
+        break;
+
+    case WayPointFollowerSTMstates::FOLLOW_ROUTE_INIT:
+        if (mWaypointList.isEmpty()) {
+            mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FINISHED;
+            break;
+        }
+        mCurrentState.currentWaypointIndex = 0;
+        mCurrentState.currentGoal = mWaypointList.at(0);
+        mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_GOTO_BEGIN;
+        break;
+
+    case WayPointFollowerSTMstates::FOLLOW_ROUTE_GOTO_BEGIN:
+    case WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING: {
+        if (mCurrentState.currentWaypointIndex >= mWaypointList.size()) {
+            mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
+            mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL;
+            mPrevDistanceToGoal = std::numeric_limits<double>::max();
+            break;
+        }
+
+        mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+        const double distanceToGoal =
+            getCurrentVehiclePosition().getDistanceTo3d(mCurrentState.currentGoal);
+
+        // Advance if within proximity, OR if the drone overshot — it was within
+        // 2× proximity at closest approach but is now moving away from the waypoint.
+        const bool reachedByProximity = distanceToGoal <= mWaypointProximity;
+        const bool reachedByOvershoot = mPrevDistanceToGoal <= mWaypointProximity * 2.0
+                                        && distanceToGoal > mPrevDistanceToGoal;
+        if (reachedByProximity || reachedByOvershoot) {
+            mPrevDistanceToGoal = std::numeric_limits<double>::max();
+            mCurrentState.currentWaypointIndex++;
+            if (mCurrentState.currentWaypointIndex >= mWaypointList.size()) {
+                mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
+                mCurrentState.currentGoal = mWaypointList.last();
+                mCurrentState.stmState =
+                    WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL;
+            } else {
+                mCurrentState.currentGoal = mWaypointList.at(mCurrentState.currentWaypointIndex);
+                mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FOLLOWING;
+            }
+        } else {
+            mPrevDistanceToGoal = distanceToGoal;
+        }
+
+        updateControl(mCurrentState.currentGoal);
+    } break;
+
+    case WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL: {
+        if (mWaypointList.isEmpty()) {
+            mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FINISHED;
+            break;
+        }
+
+        mCurrentState.currentWaypointIndex = mWaypointList.size() - 1;
+        mCurrentState.currentGoal = mWaypointList.last();
+        const double distanceToGoal =
+            getCurrentVehiclePosition().getDistanceTo3d(mCurrentState.currentGoal);
+        if (distanceToGoal <= mEndGoalAlignmentThreshold) {
+            if (mCurrentState.repeatRoute) {
+                mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_INIT;
+            } else {
+                qDebug() << "Copter route goal reached with accuracy:" << distanceToGoal << "m.";
+                mCurrentState.stmState = WayPointFollowerSTMstates::FOLLOW_ROUTE_FINISHED;
+            }
+        } else {
+            updateControl(mCurrentState.currentGoal);
+        }
+    } break;
+
+    case WayPointFollowerSTMstates::FOLLOW_ROUTE_FINISHED:
+        stop();
+        break;
+
+    default:
+        break;
+    }
+}
+
+void CopterWaypointFollower::updateControl(const PosPoint &goal)
+{
+    const PosPoint currentPos = getCurrentVehiclePosition();
+    const double dx = goal.getX() - currentPos.getX();
+    const double dy = goal.getY() - currentPos.getY();
+    const double dz = goal.getHeight() - currentPos.getHeight();
+    const double distance = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+    mDesiredVelocityCommand = {};
+    if (distance > std::numeric_limits<double>::epsilon()) {
+        const double speed = speedForGoal(goal, distance);
+        const double vxEnu = dx / distance * speed;
+        const double vyEnu = dy / distance * speed;
+        const double vzEnu = dz / distance * speed;
+        const double yawRad = currentPos.getYaw() * kDegToRad;
+        const double cosYaw = std::cos(yawRad);
+        const double sinYaw = std::sin(yawRad);
+
+        mDesiredVelocityCommand.forward = vxEnu * cosYaw + vyEnu * sinYaw;
+        mDesiredVelocityCommand.left = -vxEnu * sinYaw + vyEnu * cosYaw;
+        mDesiredVelocityCommand.up = vzEnu;
+
+        const double targetYawRad = mFaceTravelDirection ?
+            std::atan2(dy, dx) :
+            goal.getYaw() * kDegToRad;
+        const double yawError = normalizeAngleRad(targetYawRad - yawRad);
+        mDesiredVelocityCommand.yawRate =
+            std::clamp(mYawGain * yawError, -mMaxYawRate, mMaxYawRate);
+    }
+
+    mMovementController->setDesiredSpeed(mDesiredVelocityCommand.forward);
+    mMovementController->setDesiredSteering(mDesiredVelocityCommand.yawRate);
+    mMovementController->setDesiredAttributes(goal.getAttributes());
+
+    // Place the visual target on the approach-slowdown-radius circle facing the goal,
+    // mirroring what PurePursuit does with its lookahead circle.
+    const double dist2d = std::sqrt(dx * dx + dy * dy);
+    const QPointF circleTarget = (dist2d > mApproachSlowdownRadius)
+        ? QPointF(currentPos.getX() + dx / dist2d * mApproachSlowdownRadius,
+                  currentPos.getY() + dy / dist2d * mApproachSlowdownRadius)
+        : goal.getPoint();
+    mVehicleState->setAutopilotTargetPoint(circleTarget);
+}
+
+void CopterWaypointFollower::holdPosition()
+{
+    mDesiredVelocityCommand = {};
+    if (mMovementController) {
+        mMovementController->setDesiredSpeed(0.0);
+        mMovementController->setDesiredSteering(0.0);
+    }
+}
+
+PosPoint CopterWaypointFollower::getCurrentVehiclePosition() const
+{
+    return mVehicleState->getPosition(mPosTypeUsed);
+}
+
+int CopterWaypointFollower::findClosestWaypointIndex() const
+{
+    const PosPoint currentPos = getCurrentVehiclePosition();
+    int closestIndex = 0;
+    double closestDistance = std::numeric_limits<double>::max();
+    for (int i = 0; i < mWaypointList.size(); i++) {
+        const double distance = currentPos.getDistanceTo3d(mWaypointList.at(i));
+        if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = i;
+        }
+    }
+    return closestIndex;
+}
+
+double CopterWaypointFollower::speedForGoal(const PosPoint &goal, double distanceToGoal) const
+{
+    double speed = std::abs(goal.getSpeed());
+    if (speed <= std::numeric_limits<double>::epsilon()) {
+        speed = mCruiseSpeed;
+    }
+    speed = std::min(speed, mMaxSpeed);
+
+    if (mCurrentState.stmState == WayPointFollowerSTMstates::FOLLOW_ROUTE_APPROACHING_END_GOAL &&
+        mApproachSlowdownRadius > 0.0 && distanceToGoal < mApproachSlowdownRadius)
+    {
+        const double scaledSpeed = speed * distanceToGoal / mApproachSlowdownRadius;
+        speed = std::max(mMinApproachSpeed, scaledSpeed);
+    }
+
+    return speed;
+}
+
+double CopterWaypointFollower::normalizeAngleRad(double angle)
+{
+    while (angle > M_PI) {
+        angle -= 2.0 * M_PI;
+    }
+    while (angle < -M_PI) {
+        angle += 2.0 * M_PI;
+    }
+    return angle;
+}

--- a/autopilot/copterwaypointfollower.h
+++ b/autopilot/copterwaypointfollower.h
@@ -1,0 +1,110 @@
+/*
+ *     Copyright 2026 RISE Research Institutes of Sweden AB, Safety and Transport   waywise@ri.se
+ *     Published under GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Waypoint follower for multicopters. It follows ENU waypoints and produces body-frame
+ * velocity plus yaw-rate commands suitable for a velocity offboard bridge.
+ */
+
+#ifndef COPTERWAYPOINTFOLLOWER_H
+#define COPTERWAYPOINTFOLLOWER_H
+
+#include <QSharedPointer>
+#include <QTimer>
+
+#include "autopilot/purepursuitwaypointfollower.h"
+#include "vehicles/controller/movementcontroller.h"
+
+struct CopterVelocityCommand {
+    double forward = 0.0;  // body x, [m/s]
+    double left = 0.0;     // body y, [m/s]
+    double up = 0.0;       // body z, [m/s]
+    double yawRate = 0.0;  // ENU yaw rate, [rad/s]
+};
+
+class CopterWaypointFollower : public WaypointFollower
+{
+    Q_OBJECT
+public:
+    explicit CopterWaypointFollower(QSharedPointer<MovementController> movementController,
+                                    PosType posTypeUsed = PosType::odom);
+
+    virtual bool getRepeatRoute() const override;
+    virtual void setRepeatRoute(bool value) override;
+
+    virtual const PosPoint getCurrentGoal() override;
+
+    virtual void clearRoute() override;
+    virtual void addWaypoint(const PosPoint &point) override;
+    virtual void addRoute(const QList<PosPoint>& route) override;
+    virtual QList<PosPoint> getCurrentRoute() override;
+
+    virtual void startFollowingRoute(bool fromBeginning) override;
+    virtual bool isActive() override;
+    virtual void stop() override;
+    virtual void resetState() override;
+
+    WayPointFollowerState getCurrentState() const {return mCurrentState;}
+    CopterVelocityCommand getDesiredVelocityCommand() const {return mDesiredVelocityCommand;}
+
+    PosType getPosTypeUsed() const;
+    void setPosTypeUsed(const PosType &posTypeUsed);
+
+    double getWaypointProximity() const {return mWaypointProximity;}
+    void setWaypointProximity(double value) {mWaypointProximity = value;}
+
+    double getEndGoalAlignmentThreshold() const {return mEndGoalAlignmentThreshold;}
+    void setEndGoalAlignmentThreshold(double value) {mEndGoalAlignmentThreshold = value;}
+
+    double getCruiseSpeed() const {return mCruiseSpeed;}
+    void setCruiseSpeed(double value) {mCruiseSpeed = value;}
+
+    double getMaxSpeed() const {return mMaxSpeed;}
+    void setMaxSpeed(double value) {mMaxSpeed = value;}
+
+    double getMinApproachSpeed() const {return mMinApproachSpeed;}
+    void setMinApproachSpeed(double value) {mMinApproachSpeed = value;}
+
+    double getApproachSlowdownRadius() const {return mApproachSlowdownRadius;}
+    void setApproachSlowdownRadius(double value) {mApproachSlowdownRadius = value;}
+
+    bool getFaceTravelDirection() const {return mFaceTravelDirection;}
+    void setFaceTravelDirection(bool value) {mFaceTravelDirection = value;}
+
+    double getYawGain() const {return mYawGain;}
+    void setYawGain(double value) {mYawGain = value;}
+
+    double getMaxYawRate() const {return mMaxYawRate;}
+    void setMaxYawRate(double value) {mMaxYawRate = value;}
+
+private:
+    void updateState();
+    void updateControl(const PosPoint &goal);
+    void holdPosition();
+    PosPoint getCurrentVehiclePosition() const;
+    int findClosestWaypointIndex() const;
+    double speedForGoal(const PosPoint &goal, double distanceToGoal) const;
+    static double normalizeAngleRad(double angle);
+
+    WayPointFollowerState mCurrentState;
+    PosType mPosTypeUsed = PosType::odom;
+    QSharedPointer<MovementController> mMovementController;
+    QSharedPointer<VehicleState> mVehicleState;
+    QList<PosPoint> mWaypointList;
+    QTimer mUpdateStateTimer;
+    unsigned mUpdateStatePeriod_ms = 50;
+
+    CopterVelocityCommand mDesiredVelocityCommand;
+    double mPrevDistanceToGoal = std::numeric_limits<double>::max(); // overshoot detection
+    double mWaypointProximity = 0.5;            // [m]
+    double mEndGoalAlignmentThreshold = 0.25;   // [m]
+    double mCruiseSpeed = 1.0;                  // [m/s]
+    double mMaxSpeed = 2.0;                     // [m/s]
+    double mMinApproachSpeed = 0.1;             // [m/s]
+    double mApproachSlowdownRadius = 1.5;       // [m]
+    bool mFaceTravelDirection = true;
+    double mYawGain = 1.5;                      // [1/s]
+    double mMaxYawRate = 1.0;                   // [rad/s]
+};
+
+#endif // COPTERWAYPOINTFOLLOWER_H

--- a/autopilot/copterwaypointfollower.h
+++ b/autopilot/copterwaypointfollower.h
@@ -46,6 +46,7 @@ public:
 
     WayPointFollowerState getCurrentState() const {return mCurrentState;}
     CopterVelocityCommand getDesiredVelocityCommand() const {return mDesiredVelocityCommand;}
+    bool isClimbingToStartWaypointHeight() const {return mClimbingToStartWaypointHeight;}
 
     PosType getPosTypeUsed() const;
     void setPosTypeUsed(const PosType &posTypeUsed);
@@ -62,6 +63,9 @@ public:
     double getMaxSpeed() const {return mMaxSpeed;}
     void setMaxSpeed(double value) {mMaxSpeed = value;}
 
+    double getDescentSpeed() const {return mDescentSpeed;}
+    void setDescentSpeed(double value) {mDescentSpeed = value;}
+
     double getMinApproachSpeed() const {return mMinApproachSpeed;}
     void setMinApproachSpeed(double value) {mMinApproachSpeed = value;}
 
@@ -77,12 +81,33 @@ public:
     double getMaxYawRate() const {return mMaxYawRate;}
     void setMaxYawRate(double value) {mMaxYawRate = value;}
 
+    double getVerticalHeightTolerance() const {return mVerticalHeightTolerance;}
+    void setVerticalHeightTolerance(double value) {mVerticalHeightTolerance = value;}
+
+    double getVerticalProportionalGain() const {return mVerticalProportionalGain;}
+    void setVerticalProportionalGain(double value) {mVerticalProportionalGain = value;}
+
+    double getVerticalIntegralGain() const {return mVerticalIntegralGain;}
+    void setVerticalIntegralGain(double value) {mVerticalIntegralGain = value;}
+
+    double getVerticalDerivativeGain() const {return mVerticalDerivativeGain;}
+    void setVerticalDerivativeGain(double value) {mVerticalDerivativeGain = value;}
+
+    double getVerticalIntegralLimit() const {return mVerticalIntegralLimit;}
+    void setVerticalIntegralLimit(double value) {mVerticalIntegralLimit = value;}
+
 private:
     void updateState();
     void updateControl(const PosPoint &goal);
+    void updateTrackingControl(const PosPoint &goal);
+    void updateClimbControl(const PosPoint &goal);
     void holdPosition();
+    bool isVerticalLeg(int waypointIndex) const;
+    PosPoint waypointHeightAtCurrentPosition(int waypointIndex) const;
+    double verticalLegReferenceHeight(int waypointIndex) const;
     PosPoint getCurrentVehiclePosition() const;
-    int findClosestWaypointIndex() const;
+    int findClosestSegmentStartIndex() const;
+    double descentSpeedForGoal(const PosPoint &goal) const;
     double speedForGoal(const PosPoint &goal, double distanceToGoal) const;
     static double normalizeAngleRad(double angle);
 
@@ -95,16 +120,25 @@ private:
     unsigned mUpdateStatePeriod_ms = 50;
 
     CopterVelocityCommand mDesiredVelocityCommand;
+    bool mClimbingToStartWaypointHeight = false;
+    bool mSkipStartWaypointAfterClimb = false;
+    double mVerticalHeightErrorIntegral = 0.0;
     double mPrevDistanceToGoal = std::numeric_limits<double>::max(); // overshoot detection
     double mWaypointProximity = 0.5;            // [m]
     double mEndGoalAlignmentThreshold = 0.25;   // [m]
     double mCruiseSpeed = 1.0;                  // [m/s]
     double mMaxSpeed = 2.0;                     // [m/s]
+    double mDescentSpeed = 0.3;                 // [m/s]
     double mMinApproachSpeed = 0.1;             // [m/s]
     double mApproachSlowdownRadius = 1.5;       // [m]
     bool mFaceTravelDirection = true;
     double mYawGain = 1.5;                      // [1/s]
     double mMaxYawRate = 1.0;                   // [rad/s]
+    double mVerticalHeightTolerance = 0.10;      // [m]
+    double mVerticalProportionalGain = 0.8;      // [1/s]
+    double mVerticalIntegralGain = 0.04;         // [1/s^2]
+    double mVerticalDerivativeGain = 0.5;        // dimensionless damping on vertical speed
+    double mVerticalIntegralLimit = 2.0;         // [m*s]
 };
 
 #endif // COPTERWAYPOINTFOLLOWER_H


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature

* **What is the current behavior?** (You can also link to an open issue here)

  Currently, the WayWise core only supports waypoint following for ground vehicles 

* **What is the new behavior (if this is a feature change)?**

  This PR introduces the CopterWaypointFollower module, a new autopilot dedicated to multi-rotor UAV navigation. Key additions include:
  
  - Copter-Specific State Machine: A robust state machine handling route initialization, waypoint-to-waypoint navigation, goal approach, and route repetition.
  - Body-Frame Control: Generates precise body-frame velocity commands (forward, left, up) and yaw rate commands to follow ENU (East-North-Up) routes.
  - Vertical Climb Control: Implements a PID-based vertical tracker that ensures the copter safely climbs to the first waypoint's altitude before initiating any horizontal movement (mClimbingToStartWaypointHeight), avoiding ground obstacles on takeoff.
  - Advanced Segment Tracking: Replaces simple point-to-point proximity checks with orthogonal projection along the path segment (findClosestSegmentStartIndex) for smoother tracking and transition logic.
  - Approach & Descent Management: Includes tunable parameters for approach slowdown radii, descent speeds, and overshoot detection to guarantee smooth deceleration at the end of a mission.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  No. The CopterWaypointFollower is an entirely new class.

* **Other information**:


